### PR TITLE
Botanic Miner Changes

### DIFF
--- a/config/environmentaltech/multiblocks/void_miner/botanic/tier_2.json
+++ b/config/environmentaltech/multiblocks/void_miner/botanic/tier_2.json
@@ -227,13 +227,8 @@
     },
 	{
       "target": "green",
-      "weight": 4,
-      "id": "quark:variant_sapling:0"
-    },
-	{
-      "target": "pink",
-      "weight": 4,
-      "id": "quark:variant_sapling:1"
+      "weight": 8,
+      "id": "forestry:sapling"
     },
 	{
       "target": "green",
@@ -579,6 +574,11 @@
       "target": "lime",
       "weight": 6,
       "id": "minecraft:reeds:0"
+    },
+	  {
+      "target": "light_blue",
+      "weight": 14,
+      "id": "randomthings:glowinsmushroom"
     },
     {
       "target": "red",

--- a/config/environmentaltech/multiblocks/void_miner/botanic/tier_2.json
+++ b/config/environmentaltech/multiblocks/void_miner/botanic/tier_2.json
@@ -578,7 +578,7 @@
 	  {
       "target": "light_blue",
       "weight": 14,
-      "id": "randomthings:glowinsmushroom"
+      "id": "randomthings:glowingmushroom"
     },
     {
       "target": "red",

--- a/config/environmentaltech/multiblocks/void_miner/botanic/tier_3.json
+++ b/config/environmentaltech/multiblocks/void_miner/botanic/tier_3.json
@@ -746,7 +746,7 @@
       "id": "randomthings:ingredient:2"
     },
 	  {
-      "target": "blue",
+      "target": "light_blue",
       "weight": 14,
       "id": "randomthings:glowingmushroom"
     },

--- a/config/environmentaltech/multiblocks/void_miner/botanic/tier_3.json
+++ b/config/environmentaltech/multiblocks/void_miner/botanic/tier_3.json
@@ -297,13 +297,8 @@
     },
 	{
       "target": "green",
-      "weight": 4,
-      "id": "quark:variant_sapling:0"
-    },
-	{
-      "target": "pink",
-      "weight": 4,
-      "id": "quark:variant_sapling:1"
+      "weight": 8,
+      "id": "forestry:sapling"
     },
 	{
       "target": "green",
@@ -749,6 +744,11 @@
       "target": "blue",
       "weight": 14,
       "id": "randomthings:ingredient:2"
+    },
+	  {
+      "target": "blue",
+      "weight": 14,
+      "id": "randomthings:glowingmushroom"
     },
     {
       "target": "red",

--- a/config/environmentaltech/multiblocks/void_miner/botanic/tier_4.json
+++ b/config/environmentaltech/multiblocks/void_miner/botanic/tier_4.json
@@ -831,7 +831,7 @@
       "id": "randomthings:ingredient:2"
     },
 	{
-      "target": "blue",
+      "target": "light_blue",
       "weight": 14,
       "id": "randomthings:glowingmushroom"
     },

--- a/config/environmentaltech/multiblocks/void_miner/botanic/tier_4.json
+++ b/config/environmentaltech/multiblocks/void_miner/botanic/tier_4.json
@@ -317,13 +317,8 @@
     },
 	{
       "target": "green",
-      "weight": 4,
-      "id": "quark:variant_sapling:0"
-    },
-	{
-      "target": "pink",
-      "weight": 4,
-      "id": "quark:variant_sapling:1"
+      "weight": 16,
+      "id": "forestry:sapling"
     },
 	{
       "target": "crystal",
@@ -834,6 +829,11 @@
       "target": "blue",
       "weight": 14,
       "id": "randomthings:ingredient:2"
+    },
+	{
+      "target": "blue",
+      "weight": 14,
+      "id": "randomthings:glowingmushroom"
     },
     {
       "target": "red",

--- a/config/environmentaltech/multiblocks/void_miner/botanic/tier_5.json
+++ b/config/environmentaltech/multiblocks/void_miner/botanic/tier_5.json
@@ -891,7 +891,7 @@
       "id": "randomthings:ingredient:2"
     },
 	{
-      "target": "blue",
+      "target": "light_blue",
       "weight": 28,
       "id": "randomthings:glowingmushroom"
     },

--- a/config/environmentaltech/multiblocks/void_miner/botanic/tier_5.json
+++ b/config/environmentaltech/multiblocks/void_miner/botanic/tier_5.json
@@ -347,13 +347,8 @@
     },
 	{
       "target": "green",
-      "weight": 4,
-      "id": "quark:variant_sapling:0"
-    },
-	{
-      "target": "pink",
-      "weight": 4,
-      "id": "quark:variant_sapling:1"
+      "weight": 28,
+      "id": "forestry:sapling"
     },
 	{
       "target": "crystal",
@@ -894,6 +889,11 @@
       "target": "blue",
       "weight": 28,
       "id": "randomthings:ingredient:2"
+    },
+	{
+      "target": "blue",
+      "weight": 28,
+      "id": "randomthings:glowingmushroom"
     },
     {
       "target": "red",

--- a/config/environmentaltech/multiblocks/void_miner/botanic/tier_6.json
+++ b/config/environmentaltech/multiblocks/void_miner/botanic/tier_6.json
@@ -918,7 +918,7 @@
 	{
       "target": "light_blue",
       "weight": 28,
-      "id": "randomthings:glowshroom"
+      "id": "randomthings:glowingmushroom"
     },
     {
       "target": "red",

--- a/config/environmentaltech/multiblocks/void_miner/botanic/tier_6.json
+++ b/config/environmentaltech/multiblocks/void_miner/botanic/tier_6.json
@@ -347,13 +347,8 @@
     },
 	{
       "target": "green",
-      "weight": 4,
-      "id": "quark:variant_sapling:0"
-    },
-	{
-      "target": "pink",
-      "weight": 4,
-      "id": "quark:variant_sapling:1"
+      "weight": 50,
+      "id": "forestry:sapling"
     },
 	{
       "target": "crystal",
@@ -919,6 +914,11 @@
       "target": "blue",
       "weight": 28,
       "id": "randomthings:ingredient:2"
+    },
+	{
+      "target": "light_blue",
+      "weight": 28,
+      "id": "randomthings:glowshroom"
     },
     {
       "target": "red",


### PR DESCRIPTION
- Removed the Quark Saplings, mostly to keep the number of entries the same
- Added the randomthings glowing mushroom starting at tier 2 because those are needed in the thousands for gaia spirits with no way of automating them currently, same as what I already sent in the private chat other than the lens color which I changed to light blue
- Added a forestry sapling, more specifically the default apple oak sapling, starting at tier 2 because the alternative for getting dna would be an unreasonable amount of hiveacynths or an even more unreasonable amount of hopping bonsai pots (my idea for the botanic miner was to be somewhat of an upgrade to bonsai pots)