### PR TITLE
Factory Multiblock Fix

### DIFF
--- a/config/multiblocked/definition/controller/the_factory_mk_1.json
+++ b/config/multiblocked/definition/controller/the_factory_mk_1.json
@@ -60,9 +60,9 @@
         "ABA"
       ],
       [
-        "BGB",
+        "BCB",
         "AD@",
-        "BCB"
+        "BGB"
       ],
       [
         "ABA",

--- a/config/multiblocked/definition/controller/the_factory_mk_2.json
+++ b/config/multiblocked/definition/controller/the_factory_mk_2.json
@@ -60,9 +60,9 @@
         "ABA"
       ],
       [
-        "BGB",
+        "BCB",
         "AD@",
-        "BCB"
+        "BGB"
       ],
       [
         "ABA",

--- a/config/multiblocked/definition/controller/the_factory_mk_3.json
+++ b/config/multiblocked/definition/controller/the_factory_mk_3.json
@@ -60,9 +60,9 @@
         "CBC"
       ],
       [
-        "BIB",
+        "BDB",
         "EF@",
-        "BDB"
+        "BIB"
       ],
       [
         "CBC",


### PR DESCRIPTION
This swaps the bottom and the top layers of the Factory Multiblocks, putting the Lightning Cell into the top layer, which will allow it to get charged without destroying the multiblock.