### PR TITLE
Tier 6 Seeds

### DIFF
--- a/scripts/crafttweaker/addingrecipes/bymod/mystical/crafting.zs
+++ b/scripts/crafttweaker/addingrecipes/bymod/mystical/crafting.zs
@@ -258,3 +258,13 @@ recipes.addShaped("essencecreativema", <mysticalagradditions:stuff:69>, [
 [<contenttweaker:empowered_essence>, <mysticalagriculture:crafting:4>, <contenttweaker:empowered_essence>],
 [<extendedcrafting:material:12>, <contenttweaker:empowered_essence>, <extendedcrafting:material:12>]
 ]);
+
+//dragon egg
+recipes.addShapeless("dragoneggfromchunk", <minecraft:dragon_egg>, [<mysticalagradditions:stuff:2>, <mysticalagradditions:stuff:2>, <mysticalagradditions:stuff:2>]);
+
+//nether star
+recipes.addShaped("netherstarfromnuggets", <minecraft:nether_star>, [
+[<lightningcraft:material>, <lightningcraft:material>, <lightningcraft:material>],
+[<lightningcraft:material>, <lightningcraft:material>, <lightningcraft:material>],
+[<lightningcraft:material>, <lightningcraft:material>, <lightningcraft:material>]
+]);

--- a/scripts/crafttweaker/addingrecipes/bymod/mystical/tiersix.zs
+++ b/scripts/crafttweaker/addingrecipes/bymod/mystical/tiersix.zs
@@ -4,26 +4,21 @@ import mods.extendedcrafting.CombinationCrafting;
 val seeds = [
 	<mysticalagradditions:dragon_egg_seeds>,
 	<mysticalagradditions:nether_star_seeds>,
-	<mysticalagradditions:awakened_draconium_seeds>
+	<mysticalagradditions:awakened_draconium_seeds>,
+	<mysticalagradditions:neutronium_seeds>
 ] as IItemStack[];
 
 val blocks = [
 	<minecraft:dragon_egg>,
 	<overloaded:nether_star_block>,
-	<draconicevolution:draconic_block>
+	<draconicevolution:draconic_block>,
+	<avaritia:block_resource>
 ] as IItemStack[];
 
 for i, seed in seeds {
 	CombinationCrafting.addRecipe(seeds[i], 1000000000, 50000000, <mysticalagradditions:insanium:1>, [blocks[i], blocks[i], blocks[i], blocks[i], blocks[i], blocks[i], blocks[i], blocks[i], 
 	blocks[i], blocks[i], blocks[i], blocks[i], blocks[i], blocks[i], blocks[i], blocks[i], blocks[i], blocks[i], blocks[i], blocks[i], blocks[i], blocks[i], blocks[i], blocks[i], <extendedcrafting:storage:4>]);
 }
-
-//neutronium
-CombinationCrafting.addRecipe(<mysticalagradditions:neutronium_seeds>, 10000000000, 500000000, <mysticalagradditions:insanium:1>, [<avaritia:block_resource>, <avaritia:block_resource>,
-	<avaritia:block_resource>, <avaritia:block_resource>, <avaritia:block_resource>, <avaritia:block_resource>, <avaritia:block_resource>, <avaritia:block_resource>, <avaritia:block_resource>, 
-	<avaritia:block_resource>, <avaritia:block_resource>, <avaritia:block_resource>, <avaritia:block_resource>, <avaritia:block_resource>, <avaritia:block_resource>, <avaritia:block_resource>, 
-	<avaritia:block_resource>, <avaritia:block_resource>, <avaritia:block_resource>, <avaritia:block_resource>, <avaritia:block_resource>, <avaritia:block_resource>, <avaritia:block_resource>, 
-	<avaritia:block_resource>, <avaritia:block_resource:1>]);
 
 val essences = [
 	<mysticalagradditions:dragon_egg_essence>,


### PR DESCRIPTION
This adds a recipe for dragon egg chunks to dragon eggs (the default recipe), a recipe for Nether Star Nuggets to Nether Stars (9 to 1 since it's 1 to 9 the other way), and reduces the RF cost of Neutronium Seeds to make them craftable.

This fixes #34 and fixes #38 and takes care of the pile of neutrons thing mentioned in #6 and the dragon egg thing mentioned in #7 