### PR TITLE
Recipe for the Creative Mill

### DIFF
--- a/scripts/crafttweaker/addingrecipes/bymod/extrautils2/resonator
+++ b/scripts/crafttweaker/addingrecipes/bymod/extrautils2/resonator
@@ -1,0 +1,3 @@
+#reloadable
+
+mods.extrautils2.Resonator.add(<extrautils2:passivegenerator:6>, <extendedcrafting:storage:4>, 240000);


### PR DESCRIPTION
This requires one block of the Ultimate and 2400 GP, which is equal to one stack of Dragon Egg Mills.

Each Ultimate Ingot requires 16k red coal and even with 2400 GP you can only barely power 2 resonators with 64 speed upgrades, so making red coal take a bunch of time, and this doesn't even count everything else that needs GP. Once you can make Ultimate Ingots, there won't be anything else that unlocks that requires GP, it's only upscaling from here, and you need too many Ultimate Ingots later on for the creative mill to unlock later than this.