### PR TITLE
VRM - more space rocks

### DIFF
--- a/config/environmentaltech/multiblocks/void_miner/resource/tier_5.json
+++ b/config/environmentaltech/multiblocks/void_miner/resource/tier_5.json
@@ -11,6 +11,26 @@
       "id": "extraplanets:neptune:2"
     },
     {
+      "target": "magenta",
+      "weight": 32,
+      "id": "zollerngalaxy:edenrock"
+    },
+    {
+      "target": "yellow",
+      "weight": 32,
+      "id": "extraplanets:io"
+    },
+    {
+      "target": "orange",
+      "weight": 32,
+      "id": "extraplanets:jupiter:2"
+    },
+    {
+      "target": "brown",
+      "weight": 32,
+      "id": "galacticraft:mars:9"
+    },
+    {
       "target": "pink",
       "weight": 30,
       "id": "minecraft:stone:1"

--- a/config/environmentaltech/multiblocks/void_miner/resource/tier_6.json
+++ b/config/environmentaltech/multiblocks/void_miner/resource/tier_6.json
@@ -11,6 +11,21 @@
       "id": "extraplanets:neptune:2"
     },
     {
+      "target": "magenta",
+      "weight": 32,
+      "id": "zollerngalaxy:edenrock"
+    },
+    {
+      "target": "yellow",
+      "weight": 32,
+      "id": "extraplanets:io"
+    },
+    {
+      "target": "orange",
+      "weight": 32,
+      "id": "extraplanets:jupiter:2"
+    },
+    {
       "target": "pink",
       "weight": 30,
       "id": "minecraft:stone:1"


### PR DESCRIPTION
This adds 3 more space rocks for T5+ so that the neptune stone is not the only one.

Only 3 to not decrease the overall weights too much, and lenses that aren't needed for compressed stuff.

I somewhat tried to go for diverse colors. The added blocks are Edenrock Stone, Io Surface Rock, Jupiter Stone, the picture also includes the already included Neptune Stone.
![grafik](https://github.com/user-attachments/assets/967ae6e0-14da-49c1-9523-89c036666b06)
