### PR TITLE
Void Miner Changes

### DIFF
--- a/config/environmentaltech/multiblocks/void_miner/botanic/tier_1.json
+++ b/config/environmentaltech/multiblocks/void_miner/botanic/tier_1.json
@@ -63,11 +63,6 @@
     {
       "target": "green",
       "weight": 32,
-      "id": "minecraft:leaves:0"
-    },
-    {
-      "target": "green",
-      "weight": 32,
       "id": "minecraft:leaves:1"
     },
     {

--- a/config/environmentaltech/multiblocks/void_miner/botanic/tier_2.json
+++ b/config/environmentaltech/multiblocks/void_miner/botanic/tier_2.json
@@ -233,11 +233,6 @@
     {
       "target": "green",
       "weight": 32,
-      "id": "minecraft:leaves:0"
-    },
-    {
-      "target": "green",
-      "weight": 32,
       "id": "minecraft:leaves:1"
     },
     {

--- a/config/environmentaltech/multiblocks/void_miner/botanic/tier_3.json
+++ b/config/environmentaltech/multiblocks/void_miner/botanic/tier_3.json
@@ -308,11 +308,6 @@
     {
       "target": "green",
       "weight": 32,
-      "id": "minecraft:leaves:0"
-    },
-    {
-      "target": "green",
-      "weight": 32,
       "id": "minecraft:leaves:1"
     },
     {

--- a/config/environmentaltech/multiblocks/void_miner/botanic/tier_4.json
+++ b/config/environmentaltech/multiblocks/void_miner/botanic/tier_4.json
@@ -373,7 +373,7 @@
     {
       "target": "green",
       "weight": 32,
-      "id": "minecraft:leaves:0"
+      "id": "twilightforest:giant_leaves"
     },
     {
       "target": "green",

--- a/config/environmentaltech/multiblocks/void_miner/botanic/tier_5.json
+++ b/config/environmentaltech/multiblocks/void_miner/botanic/tier_5.json
@@ -403,7 +403,7 @@
     {
       "target": "green",
       "weight": 32,
-      "id": "minecraft:leaves:0"
+      "id": "twilightforest:giant_leaves"
     },
     {
       "target": "green",

--- a/config/environmentaltech/multiblocks/void_miner/botanic/tier_6.json
+++ b/config/environmentaltech/multiblocks/void_miner/botanic/tier_6.json
@@ -403,7 +403,7 @@
     {
       "target": "green",
       "weight": 32,
-      "id": "minecraft:leaves:0"
+      "id": "twilightforest:giant_leaves"
     },
     {
       "target": "green",

--- a/config/environmentaltech/multiblocks/void_miner/resource/tier_1.json
+++ b/config/environmentaltech/multiblocks/void_miner/resource/tier_1.json
@@ -212,11 +212,6 @@
     },
     {
       "target": "green",
-      "weight": 5,
-      "id": "thebetweenlands:generic_stone"
-    },
-    {
-      "target": "green",
       "weight": 15,
       "id": "thebetweenlands:pitstone"
     },

--- a/config/environmentaltech/multiblocks/void_miner/resource/tier_2.json
+++ b/config/environmentaltech/multiblocks/void_miner/resource/tier_2.json
@@ -222,11 +222,6 @@
     },
     {
       "target": "green",
-      "weight": 5,
-      "id": "thebetweenlands:generic_stone"
-    },
-    {
-      "target": "green",
       "weight": 15,
       "id": "thebetweenlands:pitstone"
     },

--- a/config/environmentaltech/multiblocks/void_miner/resource/tier_3.json
+++ b/config/environmentaltech/multiblocks/void_miner/resource/tier_3.json
@@ -227,11 +227,6 @@
     },
     {
       "target": "green",
-      "weight": 5,
-      "id": "thebetweenlands:generic_stone"
-    },
-    {
-      "target": "green",
       "weight": 15,
       "id": "thebetweenlands:pitstone"
     },

--- a/config/environmentaltech/multiblocks/void_miner/resource/tier_4.json
+++ b/config/environmentaltech/multiblocks/void_miner/resource/tier_4.json
@@ -227,11 +227,6 @@
     },
     {
       "target": "green",
-      "weight": 5,
-      "id": "thebetweenlands:generic_stone"
-    },
-    {
-      "target": "green",
       "weight": 15,
       "id": "thebetweenlands:pitstone"
     },

--- a/config/environmentaltech/multiblocks/void_miner/resource/tier_5.json
+++ b/config/environmentaltech/multiblocks/void_miner/resource/tier_5.json
@@ -252,11 +252,6 @@
     },
     {
       "target": "green",
-      "weight": 5,
-      "id": "thebetweenlands:generic_stone"
-    },
-    {
-      "target": "green",
       "weight": 15,
       "id": "thebetweenlands:pitstone"
     },

--- a/config/environmentaltech/multiblocks/void_miner/resource/tier_6.json
+++ b/config/environmentaltech/multiblocks/void_miner/resource/tier_6.json
@@ -247,11 +247,6 @@
     },
     {
       "target": "green",
-      "weight": 5,
-      "id": "thebetweenlands:generic_stone"
-    },
-    {
-      "target": "green",
       "weight": 15,
       "id": "thebetweenlands:pitstone"
     },


### PR DESCRIPTION
This changes 2 things:

**1. Remove Corrupt Betweenstone**
This removes Corrupt Betweenstone from all Void Resource Miner tiers.
This reduces the amount of items in the Void Resource Miner from 101 (a prime) to 100, making it a nice round number.
Corrupt Betweenstone was chosen somewhat arbitrarily, somewhat based on the fact that Betweenstone still exists in the VRM so it won't take away as much from the felt variety as removing other unused blocks would.


**2. Replace Oak Leaves with Giant Leaves**
This removes Oak Leaves from all tiers of the Void Botanic Miner and instead adds Giant Leaves to the T4+.
Giant Leaves can be crafted into Oak Leaves, that is the reasoning behind replacing Oak Leaves specifically. (Plus I wanted to keep the nice round number of items but didn't find anything better to remove)
With the recent additions (one example being Luck Modifiers being used in a multiblock and being available at all for eg Void Miners) the pack has gotten a bit more Ritual of the Forest and thus a lot more leaf-heavy in the late-endgame. This makes it easier to get more leaves, but not too easy due to the green lens being preferred, and it by proxy keeps oak leaves even if only in later tiers.