### PR TITLE
Boots of the Marsh Runner

### DIFF
--- a/config/betterquesting/DefaultQuests.json
+++ b/config/betterquesting/DefaultQuests.json
@@ -26990,6 +26990,7 @@
       "questID:3": 650,
       "tasks:9": {
         "0:10": {
+          "ignoreNBT:1": 1,
           "index:3": 0,
           "requiredItems:9": {
             "0:10": {


### PR DESCRIPTION
This fixes #115 

It only adds one line ("ignoreNBT:1": 1,), but it's defaultQuests.