### PR TITLE
Add items to boss quests

### DIFF
--- a/config/betterquesting/DefaultQuests.json
+++ b/config/betterquesting/DefaultQuests.json
@@ -194,14 +194,15 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 1,
-          "desc:8": "     Your first encounter with a strong monster. A shield will help in defeating this annoying snake.\n\n§c§lHint:§r§c Wait for the naga to pause. This means it is getting ready to charge at you! This is when you should raise your shield, since that is how you stun it. There is also an audio cue for when it charges.",
+          "desc:8": "     Your first encounter with a strong monster. A shield will help in defeating this annoying snake.\n\n§c§lHint:§r§c Wait for the naga to pause. This means it is getting ready to charge at you! This is when you should raise your shield, since that is how you stun it. There is also an audio cue for when it charges.\n\n§3§lNote: All boss quests can be completed by killing the boss OR collecting the drop. This is due to kill tasks not properly syncing for offline players in multiplayer. However, certain drops may also be obtainable by other means...",
           "icon:10": {
             "Count:3": 1,
             "id:8": "twilightforest:trophy"
           },
           "name:8": "Naga",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 4,
@@ -220,8 +221,191 @@
       },
       "tasks:9": {
         "0:10": {
-          "ignoreNBT:1": 1,
           "index:3": 0,
+          "target:8": "twilightforest:naga",
+          "targetNBT:10": {
+            "AABB:9": {
+              "0:6": -0.875,
+              "1:6": 0.0,
+              "2:6": -0.875,
+              "3:6": 0.875,
+              "4:6": 3.0,
+              "5:6": 0.875
+            },
+            "AbsorptionAmount:5": 0.0,
+            "Air:2": 300,
+            "ArmorDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085,
+              "2:5": 0.085,
+              "3:5": 0.085
+            },
+            "ArmorItems:9": {
+              "0:10": {},
+              "1:10": {},
+              "2:10": {},
+              "3:10": {}
+            },
+            "Attributes:9": {
+              "0:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.projectileDamage"
+              },
+              "1:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.magicDamage"
+              },
+              "2:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.jumpHeight"
+              },
+              "3:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.damageResistance"
+              },
+              "4:10": {
+                "Base:6": 0.0,
+                "Name:8": "potioncore.magicShielding"
+              },
+              "5:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.slash"
+              },
+              "6:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.pierce"
+              },
+              "7:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.impact"
+              },
+              "8:10": {
+                "Base:6": 250.0,
+                "Name:8": "generic.maxHealth"
+              },
+              "9:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.knockbackResistance"
+              },
+              "10:10": {
+                "Base:6": 0.3,
+                "Name:8": "generic.movementSpeed"
+              },
+              "11:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armor"
+              },
+              "12:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armorToughness"
+              },
+              "13:10": {
+                "Base:6": 1.0,
+                "Name:8": "forge.swimSpeed"
+              },
+              "14:10": {
+                "Base:6": 80.0,
+                "Name:8": "generic.followRange"
+              },
+              "15:10": {
+                "Base:6": 5.0,
+                "Name:8": "generic.attackDamage"
+              }
+            },
+            "CanPickUpLoot:1": 0,
+            "DeathTime:2": 0,
+            "Dimension:3": -343800852,
+            "FallDistance:5": 0.0,
+            "FallFlying:1": 0,
+            "Fire:2": -1,
+            "ForgeCaps:10": {
+              "aether:entityinfo:10": {
+                "hasSpawnArea:1": 0
+              },
+              "aether:statuseffects:10": {
+                "statusEffects:9": {}
+              },
+              "cavern:portal_cache:10": {
+                "LastDim:9": {},
+                "LastPos:9": {}
+              },
+              "dsurround:data:10": {
+                "a:1": 0,
+                "f:1": 0
+              },
+              "dsurround:entityfx:10": {},
+              "dsurround:speech:10": {},
+              "thebetweenlands:custom_step_sound:10": {},
+              "thebetweenlands:entity_gems:10": {
+                "gems:9": {}
+              },
+              "thebetweenlands:equipment:10": {
+                "amuletSlots:3": 1
+              },
+              "thebetweenlands:puppet:10": {
+                "guard:1": 0,
+                "recruitmentCost:3": 0,
+                "stay:1": 0,
+                "ticks:3": 0
+              },
+              "tinkertoolleveling:entityxp:9": {},
+              "twilightforest:cap_boss:10": {
+                "homePos:10": {
+                  "X:3": 0,
+                  "Y:3": 0,
+                  "Z:3": 0
+                },
+                "variant:3": -1
+              },
+              "twilightforest:cap_shield:10": {
+                "permshields:3": 0,
+                "tempshields:3": 0
+              }
+            },
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
+            "HandDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085
+            },
+            "HandItems:9": {
+              "0:10": {},
+              "1:10": {}
+            },
+            "Health:5": 250.0,
+            "HurtByTimestamp:3": 0,
+            "HurtTime:2": 0,
+            "Invulnerable:1": 0,
+            "Leashed:1": 0,
+            "LeftHanded:1": 0,
+            "Motion:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "OnGround:1": 0,
+            "PersistenceRequired:1": 0,
+            "PortalCooldown:3": 0,
+            "Pos:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "Rotation:9": {
+              "0:5": 1.0406785,
+              "1:5": 0.0
+            },
+            "UUIDLeast:4": -7155588274977750663,
+            "UUIDMost:4": 4431990681182293202,
+            "UpdateBlocked:1": 0,
+            "gravityFactor:6": 1.0,
+            "id:8": "twilightforest:naga"
+          },
+          "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
           "requiredItems:9": {
             "0:10": {
               "Count:3": 1,
@@ -365,14 +549,15 @@
       ],
       "properties:10": {
         "betterquesting:10": {
-          "desc:8": "     A large, sentient, and aggressive mushroom creature born out of the musty atmosphere in the §5§oFungal Forest§r biome of the §2§oErebus",
+          "desc:8": "     A large, sentient, and aggressive mushroom creature born out of the musty atmosphere in the §5§oFungal Forest§r biome of the §2§oErebus§r.\n\n§3§lNote: Mushroom Hide is not a guaranteed drop, but it\u0027s its only drop.",
           "icon:10": {
             "Count:3": 1,
             "id:8": "erebus:mushroom_helmet"
           },
           "name:8": "Crushroom",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 9,
@@ -567,6 +752,17 @@
             "id:8": "erebus:erebus.crushroom"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "Damage:2": 48,
+              "id:8": "erebus:materials"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -584,7 +780,8 @@
           },
           "name:8": "Ender Dragon",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 10,
@@ -748,6 +945,16 @@
             "id:8": "minecraft:ender_dragon"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "minecraft:dragon_egg"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -765,7 +972,8 @@
           },
           "name:8": "The Wither",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 11,
@@ -933,6 +1141,16 @@
             "id:8": "minecraft:wither"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "minecraft:nether_star"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -2114,20 +2332,21 @@
       ],
       "properties:10": {
         "betterquesting:10": {
-          "desc:8": "     Can be summoned by using a§5 §oVile Stone§r on a §d§oVoxxulon Altar§r.",
+          "desc:8": "     Can be summoned by using a§5 §oVile Stone§r on a §d§oVoxxulon Altar§r.\n\n§4§lNote: Be very mindful of the durability of your Hazmat Armor/Face Mask.",
           "icon:10": {
             "Count:3": 1,
             "id:8": "aoa3:ornate_voxxulon_statue"
           },
           "name:8": "Voxxulon",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 34,
       "rewards:9": {
         "0:10": {
-          "amount:3": 40,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -2307,6 +2526,16 @@
             "id:8": "aoa3:voxxulon"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:voxxulon_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -2453,7 +2682,8 @@
           },
           "name:8": "Twilight Lich",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 39,
@@ -2473,11 +2703,211 @@
       "tasks:9": {
         "0:10": {
           "index:3": 0,
+          "target:8": "twilightforest:lich",
+          "targetNBT:10": {
+            "AABB:9": {
+              "0:6": -0.550000011920929,
+              "1:6": 0.0,
+              "2:6": -0.550000011920929,
+              "3:6": 0.550000011920929,
+              "4:6": 2.5,
+              "5:6": 0.550000011920929
+            },
+            "AbsorptionAmount:5": 0.0,
+            "Air:2": 300,
+            "ArmorDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085,
+              "2:5": 0.085,
+              "3:5": 0.085
+            },
+            "ArmorItems:9": {
+              "0:10": {},
+              "1:10": {},
+              "2:10": {},
+              "3:10": {}
+            },
+            "Attributes:9": {
+              "0:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.projectileDamage"
+              },
+              "1:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.magicDamage"
+              },
+              "2:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.jumpHeight"
+              },
+              "3:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.damageResistance"
+              },
+              "4:10": {
+                "Base:6": 0.0,
+                "Name:8": "potioncore.magicShielding"
+              },
+              "5:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.slash"
+              },
+              "6:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.pierce"
+              },
+              "7:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.impact"
+              },
+              "8:10": {
+                "Base:6": 100.0,
+                "Name:8": "generic.maxHealth"
+              },
+              "9:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.knockbackResistance"
+              },
+              "10:10": {
+                "Base:6": 0.45000001788139343,
+                "Name:8": "generic.movementSpeed"
+              },
+              "11:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armor"
+              },
+              "12:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armorToughness"
+              },
+              "13:10": {
+                "Base:6": 1.0,
+                "Name:8": "forge.swimSpeed"
+              },
+              "14:10": {
+                "Base:6": 16.0,
+                "Name:8": "generic.followRange"
+              },
+              "15:10": {
+                "Base:6": 6.0,
+                "Name:8": "generic.attackDamage"
+              }
+            },
+            "CanPickUpLoot:1": 0,
+            "DeathTime:2": 0,
+            "Dimension:3": 7,
+            "FallDistance:5": 0.0,
+            "FallFlying:1": 0,
+            "Fire:2": -1,
+            "ForgeCaps:10": {
+              "aether:entityinfo:10": {
+                "hasSpawnArea:1": 0
+              },
+              "aether:statuseffects:10": {
+                "statusEffects:9": {}
+              },
+              "cavern:portal_cache:10": {
+                "LastDim:9": {},
+                "LastPos:9": {}
+              },
+              "dsurround:data:10": {
+                "a:1": 0,
+                "f:1": 0
+              },
+              "dsurround:entityfx:10": {},
+              "dsurround:speech:10": {},
+              "thebetweenlands:custom_step_sound:10": {},
+              "thebetweenlands:entity_gems:10": {
+                "gems:9": {}
+              },
+              "thebetweenlands:equipment:10": {
+                "amuletSlots:3": 1
+              },
+              "thebetweenlands:puppet:10": {
+                "guard:1": 0,
+                "recruitmentCost:3": 0,
+                "stay:1": 0,
+                "ticks:3": 0
+              },
+              "tinkertoolleveling:entityxp:9": {},
+              "twilightforest:cap_boss:10": {
+                "homePos:10": {
+                  "X:3": 0,
+                  "Y:3": 0,
+                  "Z:3": 0
+                },
+                "variant:3": -1
+              },
+              "twilightforest:cap_shield:10": {
+                "permshields:3": 0,
+                "tempshields:3": 0
+              }
+            },
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
+            "HandDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085
+            },
+            "HandItems:9": {
+              "0:10": {},
+              "1:10": {}
+            },
+            "Health:5": 100.0,
+            "HurtByTimestamp:3": 0,
+            "HurtTime:2": 0,
+            "Invulnerable:1": 0,
+            "Leashed:1": 0,
+            "LeftHanded:1": 0,
+            "MinionsToSummon:1": 9,
+            "Motion:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "OnGround:1": 0,
+            "PersistenceRequired:1": 0,
+            "PortalCooldown:3": 0,
+            "Pos:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "Rotation:9": {
+              "0:5": 4.1225543,
+              "1:5": 0.0
+            },
+            "ShadowClone:1": 0,
+            "ShieldStrength:1": 5,
+            "UUIDLeast:4": -5467228112540186875,
+            "UUIDMost:4": 8815382153606744788,
+            "UpdateBlocked:1": 0,
+            "gravityFactor:6": 1.0,
+            "id:8": "twilightforest:lich"
+          },
+          "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "entryLogic:8": "OR",
+          "ignoreNBT:1": 1,
+          "index:3": 1,
           "requiredItems:9": {
             "0:10": {
               "Count:3": 1,
-              "Damage:2": 1,
-              "id:8": "twilightforest:trophy"
+              "id:8": "twilightforest:shield_scepter"
+            },
+            "1:10": {
+              "Count:3": 1,
+              "id:8": "twilightforest:zombie_scepter"
+            },
+            "2:10": {
+              "Count:3": 1,
+              "id:8": "twilightforest:lifedrain_scepter"
+            },
+            "3:10": {
+              "Count:3": 1,
+              "id:8": "twilightforest:twilight_scepter"
             }
           },
           "taskID:8": "bq_standard:retrieval"
@@ -2497,9 +2927,10 @@
             "Damage:2": 4,
             "id:8": "twilightforest:trophy"
           },
-          "name:8": "Phantom Knight",
+          "name:8": "Knight Phantom",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 40,
@@ -2518,8 +2949,195 @@
       },
       "tasks:9": {
         "0:10": {
-          "ignoreNBT:1": 1,
-          "index:3": 0,
+          "index:3": 1,
+          "required:3": 6,
+          "target:8": "twilightforest:knight_phantom",
+          "targetNBT:10": {
+            "AABB:9": {
+              "0:6": -0.75,
+              "1:6": 0.0,
+              "2:6": -0.75,
+              "3:6": 0.75,
+              "4:6": 3.0,
+              "5:6": 0.75
+            },
+            "AbsorptionAmount:5": 0.0,
+            "Air:2": 300,
+            "ArmorDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085,
+              "2:5": 0.085,
+              "3:5": 0.085
+            },
+            "ArmorItems:9": {
+              "0:10": {},
+              "1:10": {},
+              "2:10": {},
+              "3:10": {}
+            },
+            "Attributes:9": {
+              "0:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.projectileDamage"
+              },
+              "1:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.magicDamage"
+              },
+              "2:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.jumpHeight"
+              },
+              "3:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.damageResistance"
+              },
+              "4:10": {
+                "Base:6": 0.0,
+                "Name:8": "potioncore.magicShielding"
+              },
+              "5:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.slash"
+              },
+              "6:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.pierce"
+              },
+              "7:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.impact"
+              },
+              "8:10": {
+                "Base:6": 35.0,
+                "Name:8": "generic.maxHealth"
+              },
+              "9:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.knockbackResistance"
+              },
+              "10:10": {
+                "Base:6": 0.699999988079071,
+                "Name:8": "generic.movementSpeed"
+              },
+              "11:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armor"
+              },
+              "12:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armorToughness"
+              },
+              "13:10": {
+                "Base:6": 1.0,
+                "Name:8": "forge.swimSpeed"
+              },
+              "14:10": {
+                "Base:6": 16.0,
+                "Name:8": "generic.followRange"
+              },
+              "15:10": {
+                "Base:6": 1.0,
+                "Name:8": "generic.attackDamage"
+              }
+            },
+            "CanPickUpLoot:1": 0,
+            "DeathTime:2": 0,
+            "Dimension:3": 7,
+            "FallDistance:5": 0.0,
+            "FallFlying:1": 0,
+            "Fire:2": -1,
+            "ForgeCaps:10": {
+              "aether:entityinfo:10": {
+                "hasSpawnArea:1": 0
+              },
+              "aether:statuseffects:10": {
+                "statusEffects:9": {}
+              },
+              "cavern:portal_cache:10": {
+                "LastDim:9": {},
+                "LastPos:9": {}
+              },
+              "dsurround:data:10": {
+                "a:1": 0,
+                "f:1": 0
+              },
+              "dsurround:entityfx:10": {},
+              "dsurround:speech:10": {},
+              "thebetweenlands:custom_step_sound:10": {},
+              "thebetweenlands:entity_gems:10": {
+                "gems:9": {}
+              },
+              "thebetweenlands:equipment:10": {
+                "amuletSlots:3": 1
+              },
+              "thebetweenlands:puppet:10": {
+                "guard:1": 0,
+                "recruitmentCost:3": 0,
+                "stay:1": 0,
+                "ticks:3": 0
+              },
+              "tinkertoolleveling:entityxp:9": {},
+              "twilightforest:cap_boss:10": {
+                "homePos:10": {
+                  "X:3": 0,
+                  "Y:3": 0,
+                  "Z:3": 0
+                },
+                "variant:3": -1
+              },
+              "twilightforest:cap_shield:10": {
+                "permshields:3": 0,
+                "tempshields:3": 0
+              }
+            },
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
+            "Formation:3": 0,
+            "HandDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085
+            },
+            "HandItems:9": {
+              "0:10": {},
+              "1:10": {}
+            },
+            "Health:5": 35.0,
+            "HurtByTimestamp:3": 0,
+            "HurtTime:2": 0,
+            "Invulnerable:1": 0,
+            "Leashed:1": 0,
+            "LeftHanded:1": 0,
+            "Motion:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "MyNumber:3": 0,
+            "OnGround:1": 0,
+            "PersistenceRequired:1": 0,
+            "PortalCooldown:3": 0,
+            "Pos:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "Rotation:9": {
+              "0:5": 3.868901,
+              "1:5": 0.0
+            },
+            "TicksProgress:3": 0,
+            "UUIDLeast:4": -9133612183907130669,
+            "UUIDMost:4": -8810482802504152508,
+            "UpdateBlocked:1": 0,
+            "gravityFactor:6": 1.0,
+            "id:8": "twilightforest:knight_phantom"
+          },
+          "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 2,
           "requiredItems:9": {
             "0:10": {
               "Count:3": 1,
@@ -2545,7 +3163,8 @@
           },
           "name:8": "Alpha Yeti",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 41,
@@ -2564,7 +3183,197 @@
       },
       "tasks:9": {
         "0:10": {
-          "index:3": 0,
+          "index:3": 1,
+          "target:8": "twilightforest:yeti_alpha",
+          "targetNBT:10": {
+            "AABB:9": {
+              "0:6": -1.899999976158142,
+              "1:6": 0.0,
+              "2:6": -1.899999976158142,
+              "3:6": 1.899999976158142,
+              "4:6": 5.0,
+              "5:6": 1.899999976158142
+            },
+            "AbsorptionAmount:5": 0.0,
+            "Air:2": 300,
+            "ArmorDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085,
+              "2:5": 0.085,
+              "3:5": 0.085
+            },
+            "ArmorItems:9": {
+              "0:10": {},
+              "1:10": {},
+              "2:10": {},
+              "3:10": {}
+            },
+            "Attributes:9": {
+              "0:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.projectileDamage"
+              },
+              "1:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.magicDamage"
+              },
+              "2:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.jumpHeight"
+              },
+              "3:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.damageResistance"
+              },
+              "4:10": {
+                "Base:6": 0.0,
+                "Name:8": "potioncore.magicShielding"
+              },
+              "5:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.slash"
+              },
+              "6:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.pierce"
+              },
+              "7:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.impact"
+              },
+              "8:10": {
+                "Base:6": 200.0,
+                "Name:8": "generic.maxHealth"
+              },
+              "9:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.knockbackResistance"
+              },
+              "10:10": {
+                "Base:6": 0.38,
+                "Name:8": "generic.movementSpeed"
+              },
+              "11:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armor"
+              },
+              "12:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armorToughness"
+              },
+              "13:10": {
+                "Base:6": 1.0,
+                "Name:8": "forge.swimSpeed"
+              },
+              "14:10": {
+                "Base:6": 40.0,
+                "Name:8": "generic.followRange"
+              },
+              "15:10": {
+                "Base:6": 1.0,
+                "Name:8": "generic.attackDamage"
+              }
+            },
+            "CanPickUpLoot:1": 0,
+            "DeathTime:2": 0,
+            "Dimension:3": 7,
+            "FallDistance:5": 0.0,
+            "FallFlying:1": 0,
+            "Fire:2": -1,
+            "ForgeCaps:10": {
+              "aether:entityinfo:10": {
+                "hasSpawnArea:1": 0
+              },
+              "aether:statuseffects:10": {
+                "statusEffects:9": {}
+              },
+              "cavern:portal_cache:10": {
+                "LastDim:9": {},
+                "LastPos:9": {}
+              },
+              "dsurround:data:10": {
+                "a:1": 0,
+                "f:1": 0
+              },
+              "dsurround:entityfx:10": {},
+              "dsurround:speech:10": {},
+              "thebetweenlands:custom_step_sound:10": {},
+              "thebetweenlands:entity_gems:10": {
+                "gems:9": {}
+              },
+              "thebetweenlands:equipment:10": {
+                "amuletSlots:3": 1
+              },
+              "thebetweenlands:puppet:10": {
+                "guard:1": 0,
+                "recruitmentCost:3": 0,
+                "stay:1": 0,
+                "ticks:3": 0
+              },
+              "tinkertoolleveling:entityxp:9": {},
+              "twilightforest:cap_boss:10": {
+                "homePos:10": {
+                  "X:3": 0,
+                  "Y:3": 0,
+                  "Z:3": 0
+                },
+                "variant:3": -1
+              },
+              "twilightforest:cap_shield:10": {
+                "permshields:3": 0,
+                "tempshields:3": 0
+              }
+            },
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
+            "HandDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085
+            },
+            "HandItems:9": {
+              "0:10": {},
+              "1:10": {}
+            },
+            "HasHome:1": 0,
+            "Health:5": 200.0,
+            "Home:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "HurtByTimestamp:3": 0,
+            "HurtTime:2": 0,
+            "Invulnerable:1": 0,
+            "Leashed:1": 0,
+            "LeftHanded:1": 0,
+            "Motion:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "OnGround:1": 0,
+            "PersistenceRequired:1": 0,
+            "PortalCooldown:3": 0,
+            "Pos:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "Rotation:9": {
+              "0:5": 4.003172,
+              "1:5": 0.0
+            },
+            "UUIDLeast:4": -7175857690462105467,
+            "UUIDMost:4": -6820329777842401424,
+            "UpdateBlocked:1": 0,
+            "gravityFactor:6": 1.0,
+            "id:8": "twilightforest:yeti_alpha"
+          },
+          "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 2,
           "requiredItems:9": {
             "0:10": {
               "Count:3": 1,
@@ -2590,7 +3399,8 @@
           },
           "name:8": "Minoshroom",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 42,
@@ -2609,13 +3419,195 @@
       },
       "tasks:9": {
         "0:10": {
-          "ignoreNBT:1": 1,
-          "index:3": 0,
+          "index:3": 1,
+          "target:8": "twilightforest:minoshroom",
+          "targetNBT:10": {
+            "AABB:9": {
+              "0:6": -0.7450000047683716,
+              "1:6": 0.0,
+              "2:6": -0.7450000047683716,
+              "3:6": 0.7450000047683716,
+              "4:6": 2.9000000953674316,
+              "5:6": 0.7450000047683716
+            },
+            "AbsorptionAmount:5": 0.0,
+            "Air:2": 300,
+            "ArmorDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085,
+              "2:5": 0.085,
+              "3:5": 0.085
+            },
+            "ArmorItems:9": {
+              "0:10": {},
+              "1:10": {},
+              "2:10": {},
+              "3:10": {}
+            },
+            "Attributes:9": {
+              "0:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.projectileDamage"
+              },
+              "1:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.magicDamage"
+              },
+              "2:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.jumpHeight"
+              },
+              "3:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.damageResistance"
+              },
+              "4:10": {
+                "Base:6": 0.0,
+                "Name:8": "potioncore.magicShielding"
+              },
+              "5:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.slash"
+              },
+              "6:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.pierce"
+              },
+              "7:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.impact"
+              },
+              "8:10": {
+                "Base:6": 120.0,
+                "Name:8": "generic.maxHealth"
+              },
+              "9:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.knockbackResistance"
+              },
+              "10:10": {
+                "Base:6": 0.25,
+                "Name:8": "generic.movementSpeed"
+              },
+              "11:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armor"
+              },
+              "12:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armorToughness"
+              },
+              "13:10": {
+                "Base:6": 1.0,
+                "Name:8": "forge.swimSpeed"
+              },
+              "14:10": {
+                "Base:6": 16.0,
+                "Name:8": "generic.followRange"
+              },
+              "15:10": {
+                "Base:6": 2.0,
+                "Name:8": "generic.attackDamage"
+              }
+            },
+            "CanPickUpLoot:1": 0,
+            "DeathTime:2": 0,
+            "Dimension:3": 7,
+            "FallDistance:5": 0.0,
+            "FallFlying:1": 0,
+            "Fire:2": -1,
+            "ForgeCaps:10": {
+              "aether:entityinfo:10": {
+                "hasSpawnArea:1": 0
+              },
+              "aether:statuseffects:10": {
+                "statusEffects:9": {}
+              },
+              "cavern:portal_cache:10": {
+                "LastDim:9": {},
+                "LastPos:9": {}
+              },
+              "dsurround:data:10": {
+                "a:1": 0,
+                "f:1": 0
+              },
+              "dsurround:entityfx:10": {},
+              "dsurround:speech:10": {},
+              "thebetweenlands:custom_step_sound:10": {},
+              "thebetweenlands:entity_gems:10": {
+                "gems:9": {}
+              },
+              "thebetweenlands:equipment:10": {
+                "amuletSlots:3": 1
+              },
+              "thebetweenlands:puppet:10": {
+                "guard:1": 0,
+                "recruitmentCost:3": 0,
+                "stay:1": 0,
+                "ticks:3": 0
+              },
+              "tinkertoolleveling:entityxp:9": {},
+              "twilightforest:cap_boss:10": {
+                "homePos:10": {
+                  "X:3": 0,
+                  "Y:3": 0,
+                  "Z:3": 0
+                },
+                "variant:3": -1
+              },
+              "twilightforest:cap_shield:10": {
+                "permshields:3": 0,
+                "tempshields:3": 0
+              }
+            },
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
+            "HandDropChances:9": {
+              "0:5": 1.1,
+              "1:5": 0.085
+            },
+            "HandItems:9": {
+              "0:10": {},
+              "1:10": {}
+            },
+            "Health:5": 120.0,
+            "HurtByTimestamp:3": 0,
+            "HurtTime:2": 0,
+            "Invulnerable:1": 0,
+            "Leashed:1": 0,
+            "LeftHanded:1": 0,
+            "Motion:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "OnGround:1": 0,
+            "PersistenceRequired:1": 0,
+            "PortalCooldown:3": 0,
+            "Pos:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "Rotation:9": {
+              "0:5": 1.3664112,
+              "1:5": 0.0
+            },
+            "UUIDLeast:4": -8650502549576401934,
+            "UUIDMost:4": 7302842290847564854,
+            "UpdateBlocked:1": 0,
+            "gravityFactor:6": 1.0,
+            "id:8": "twilightforest:minoshroom"
+          },
+          "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 2,
           "requiredItems:9": {
             "0:10": {
               "Count:3": 1,
-              "Damage:2": 6,
-              "id:8": "twilightforest:trophy"
+              "id:8": "twilightforest:meef_stroganoff"
             }
           },
           "taskID:8": "bq_standard:retrieval"
@@ -2637,7 +3629,8 @@
           },
           "name:8": "Hydra",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 43,
@@ -2657,6 +3650,188 @@
       "tasks:9": {
         "0:10": {
           "index:3": 0,
+          "target:8": "twilightforest:hydra",
+          "targetNBT:10": {
+            "AABB:9": {
+              "0:6": -8.0,
+              "1:6": 0.0,
+              "2:6": -8.0,
+              "3:6": 8.0,
+              "4:6": 12.0,
+              "5:6": 8.0
+            },
+            "AbsorptionAmount:5": 0.0,
+            "Air:2": 300,
+            "ArmorDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085,
+              "2:5": 0.085,
+              "3:5": 0.085
+            },
+            "ArmorItems:9": {
+              "0:10": {},
+              "1:10": {},
+              "2:10": {},
+              "3:10": {}
+            },
+            "Attributes:9": {
+              "0:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.projectileDamage"
+              },
+              "1:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.magicDamage"
+              },
+              "2:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.jumpHeight"
+              },
+              "3:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.damageResistance"
+              },
+              "4:10": {
+                "Base:6": 0.0,
+                "Name:8": "potioncore.magicShielding"
+              },
+              "5:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.slash"
+              },
+              "6:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.pierce"
+              },
+              "7:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.impact"
+              },
+              "8:10": {
+                "Base:6": 360.0,
+                "Name:8": "generic.maxHealth"
+              },
+              "9:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.knockbackResistance"
+              },
+              "10:10": {
+                "Base:6": 0.28,
+                "Name:8": "generic.movementSpeed"
+              },
+              "11:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armor"
+              },
+              "12:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armorToughness"
+              },
+              "13:10": {
+                "Base:6": 1.0,
+                "Name:8": "forge.swimSpeed"
+              },
+              "14:10": {
+                "Base:6": 16.0,
+                "Name:8": "generic.followRange"
+              }
+            },
+            "CanPickUpLoot:1": 0,
+            "DeathTime:2": 0,
+            "Dimension:3": 7,
+            "FallDistance:5": 0.0,
+            "FallFlying:1": 0,
+            "Fire:2": -1,
+            "ForgeCaps:10": {
+              "aether:entityinfo:10": {
+                "hasSpawnArea:1": 0
+              },
+              "aether:statuseffects:10": {
+                "statusEffects:9": {}
+              },
+              "cavern:portal_cache:10": {
+                "LastDim:9": {},
+                "LastPos:9": {}
+              },
+              "dsurround:data:10": {
+                "a:1": 0,
+                "f:1": 0
+              },
+              "dsurround:entityfx:10": {},
+              "dsurround:speech:10": {},
+              "thebetweenlands:custom_step_sound:10": {},
+              "thebetweenlands:entity_gems:10": {
+                "gems:9": {}
+              },
+              "thebetweenlands:equipment:10": {
+                "amuletSlots:3": 1
+              },
+              "thebetweenlands:puppet:10": {
+                "guard:1": 0,
+                "recruitmentCost:3": 0,
+                "stay:1": 0,
+                "ticks:3": 0
+              },
+              "tinkertoolleveling:entityxp:9": {},
+              "twilightforest:cap_boss:10": {
+                "homePos:10": {
+                  "X:3": 0,
+                  "Y:3": 0,
+                  "Z:3": 0
+                },
+                "variant:3": -1
+              },
+              "twilightforest:cap_shield:10": {
+                "permshields:3": 0,
+                "tempshields:3": 0
+              }
+            },
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
+            "HandDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085
+            },
+            "HandItems:9": {
+              "0:10": {},
+              "1:10": {}
+            },
+            "Health:5": 360.0,
+            "HurtByTimestamp:3": 0,
+            "HurtTime:2": 0,
+            "Invulnerable:1": 0,
+            "Leashed:1": 0,
+            "LeftHanded:1": 0,
+            "Motion:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "NumHeads:1": 3,
+            "OnGround:1": 0,
+            "PersistenceRequired:1": 0,
+            "PortalCooldown:3": 0,
+            "Pos:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "Rotation:9": {
+              "0:5": 3.3254828,
+              "1:5": 0.0
+            },
+            "SpawnHeads:1": 1,
+            "UUIDLeast:4": -6804134827031395226,
+            "UUIDMost:4": 1224117476361062722,
+            "UpdateBlocked:1": 0,
+            "gravityFactor:6": 1.0,
+            "id:8": "twilightforest:hydra"
+          },
+          "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
           "requiredItems:9": {
             "0:10": {
               "Count:3": 1,
@@ -2682,7 +3857,8 @@
           },
           "name:8": "Snow Queen",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 44,
@@ -2701,7 +3877,191 @@
       },
       "tasks:9": {
         "0:10": {
-          "index:3": 0,
+          "index:3": 1,
+          "target:8": "twilightforest:snow_queen",
+          "targetNBT:10": {
+            "AABB:9": {
+              "0:6": -0.3499999940395355,
+              "1:6": 0.0,
+              "2:6": -0.3499999940395355,
+              "3:6": 0.3499999940395355,
+              "4:6": 2.200000047683716,
+              "5:6": 0.3499999940395355
+            },
+            "AbsorptionAmount:5": 0.0,
+            "Air:2": 300,
+            "ArmorDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085,
+              "2:5": 0.085,
+              "3:5": 0.085
+            },
+            "ArmorItems:9": {
+              "0:10": {},
+              "1:10": {},
+              "2:10": {},
+              "3:10": {}
+            },
+            "Attributes:9": {
+              "0:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.projectileDamage"
+              },
+              "1:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.magicDamage"
+              },
+              "2:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.jumpHeight"
+              },
+              "3:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.damageResistance"
+              },
+              "4:10": {
+                "Base:6": 0.0,
+                "Name:8": "potioncore.magicShielding"
+              },
+              "5:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.slash"
+              },
+              "6:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.pierce"
+              },
+              "7:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.impact"
+              },
+              "8:10": {
+                "Base:6": 200.0,
+                "Name:8": "generic.maxHealth"
+              },
+              "9:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.knockbackResistance"
+              },
+              "10:10": {
+                "Base:6": 0.23000000417232513,
+                "Name:8": "generic.movementSpeed"
+              },
+              "11:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armor"
+              },
+              "12:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armorToughness"
+              },
+              "13:10": {
+                "Base:6": 1.0,
+                "Name:8": "forge.swimSpeed"
+              },
+              "14:10": {
+                "Base:6": 40.0,
+                "Name:8": "generic.followRange"
+              },
+              "15:10": {
+                "Base:6": 7.0,
+                "Name:8": "generic.attackDamage"
+              }
+            },
+            "CanPickUpLoot:1": 0,
+            "DeathTime:2": 0,
+            "Dimension:3": 7,
+            "FallDistance:5": 0.0,
+            "FallFlying:1": 0,
+            "Fire:2": -1,
+            "ForgeCaps:10": {
+              "aether:entityinfo:10": {
+                "hasSpawnArea:1": 0
+              },
+              "aether:statuseffects:10": {
+                "statusEffects:9": {}
+              },
+              "cavern:portal_cache:10": {
+                "LastDim:9": {},
+                "LastPos:9": {}
+              },
+              "dsurround:data:10": {
+                "a:1": 0,
+                "f:1": 0
+              },
+              "dsurround:entityfx:10": {},
+              "dsurround:speech:10": {},
+              "thebetweenlands:custom_step_sound:10": {},
+              "thebetweenlands:entity_gems:10": {
+                "gems:9": {}
+              },
+              "thebetweenlands:equipment:10": {
+                "amuletSlots:3": 1
+              },
+              "thebetweenlands:puppet:10": {
+                "guard:1": 0,
+                "recruitmentCost:3": 0,
+                "stay:1": 0,
+                "ticks:3": 0
+              },
+              "tinkertoolleveling:entityxp:9": {},
+              "twilightforest:cap_boss:10": {
+                "homePos:10": {
+                  "X:3": 0,
+                  "Y:3": 0,
+                  "Z:3": 0
+                },
+                "variant:3": 5
+              },
+              "twilightforest:cap_shield:10": {
+                "permshields:3": 0,
+                "tempshields:3": 0
+              }
+            },
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
+            "HandDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085
+            },
+            "HandItems:9": {
+              "0:10": {},
+              "1:10": {}
+            },
+            "Health:5": 200.0,
+            "HurtByTimestamp:3": 0,
+            "HurtTime:2": 0,
+            "Invulnerable:1": 0,
+            "Leashed:1": 0,
+            "LeftHanded:1": 0,
+            "Motion:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "OnGround:1": 0,
+            "PersistenceRequired:1": 0,
+            "PortalCooldown:3": 0,
+            "Pos:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "Rotation:9": {
+              "0:5": 1.8017886,
+              "1:5": 0.0
+            },
+            "UUIDLeast:4": -5626926931238720397,
+            "UUIDMost:4": -3357573187130734396,
+            "UpdateBlocked:1": 0,
+            "gravityFactor:6": 1.0,
+            "id:8": "twilightforest:snow_queen"
+          },
+          "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 2,
           "requiredItems:9": {
             "0:10": {
               "Count:3": 1,
@@ -2727,7 +4087,8 @@
           },
           "name:8": "Ur-Ghast",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 45,
@@ -2747,6 +4108,188 @@
       "tasks:9": {
         "0:10": {
           "index:3": 0,
+          "target:8": "twilightforest:ur_ghast",
+          "targetNBT:10": {
+            "AABB:9": {
+              "0:6": -7.0,
+              "1:6": 0.0,
+              "2:6": -7.0,
+              "3:6": 7.0,
+              "4:6": 18.0,
+              "5:6": 7.0
+            },
+            "AbsorptionAmount:5": 0.0,
+            "Air:2": 300,
+            "ArmorDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085,
+              "2:5": 0.085,
+              "3:5": 0.085
+            },
+            "ArmorItems:9": {
+              "0:10": {},
+              "1:10": {},
+              "2:10": {},
+              "3:10": {}
+            },
+            "Attributes:9": {
+              "0:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.projectileDamage"
+              },
+              "1:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.magicDamage"
+              },
+              "2:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.jumpHeight"
+              },
+              "3:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.damageResistance"
+              },
+              "4:10": {
+                "Base:6": 0.0,
+                "Name:8": "potioncore.magicShielding"
+              },
+              "5:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.slash"
+              },
+              "6:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.pierce"
+              },
+              "7:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.impact"
+              },
+              "8:10": {
+                "Base:6": 250.0,
+                "Name:8": "generic.maxHealth"
+              },
+              "9:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.knockbackResistance"
+              },
+              "10:10": {
+                "Base:6": 0.699999988079071,
+                "Name:8": "generic.movementSpeed"
+              },
+              "11:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armor"
+              },
+              "12:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armorToughness"
+              },
+              "13:10": {
+                "Base:6": 1.0,
+                "Name:8": "forge.swimSpeed"
+              },
+              "14:10": {
+                "Base:6": 128.0,
+                "Name:8": "generic.followRange"
+              }
+            },
+            "CanPickUpLoot:1": 0,
+            "DeathTime:2": 0,
+            "Dimension:3": 7,
+            "ExplosionPower:3": 1,
+            "FallDistance:5": 0.0,
+            "FallFlying:1": 0,
+            "Fire:2": -1,
+            "ForgeCaps:10": {
+              "aether:entityinfo:10": {
+                "hasSpawnArea:1": 0
+              },
+              "aether:statuseffects:10": {
+                "statusEffects:9": {}
+              },
+              "cavern:portal_cache:10": {
+                "LastDim:9": {},
+                "LastPos:9": {}
+              },
+              "dsurround:data:10": {
+                "a:1": 0,
+                "f:1": 0
+              },
+              "dsurround:entityfx:10": {},
+              "dsurround:speech:10": {},
+              "thebetweenlands:custom_step_sound:10": {},
+              "thebetweenlands:entity_gems:10": {
+                "gems:9": {}
+              },
+              "thebetweenlands:equipment:10": {
+                "amuletSlots:3": 1
+              },
+              "thebetweenlands:puppet:10": {
+                "guard:1": 0,
+                "recruitmentCost:3": 0,
+                "stay:1": 0,
+                "ticks:3": 0
+              },
+              "tinkertoolleveling:entityxp:9": {},
+              "twilightforest:cap_boss:10": {
+                "homePos:10": {
+                  "X:3": 0,
+                  "Y:3": 0,
+                  "Z:3": 0
+                },
+                "variant:3": -1
+              },
+              "twilightforest:cap_shield:10": {
+                "permshields:3": 0,
+                "tempshields:3": 0
+              }
+            },
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
+            "HandDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085
+            },
+            "HandItems:9": {
+              "0:10": {},
+              "1:10": {}
+            },
+            "Health:5": 250.0,
+            "HurtByTimestamp:3": 0,
+            "HurtTime:2": 0,
+            "Invulnerable:1": 0,
+            "Leashed:1": 0,
+            "LeftHanded:1": 0,
+            "Motion:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "OnGround:1": 0,
+            "PersistenceRequired:1": 0,
+            "PortalCooldown:3": 0,
+            "Pos:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "Rotation:9": {
+              "0:5": 5.2810383,
+              "1:5": 0.0
+            },
+            "UUIDLeast:4": -7320391652265759394,
+            "UUIDMost:4": -5346192301575747205,
+            "UpdateBlocked:1": 0,
+            "gravityFactor:6": 1.0,
+            "id:8": "twilightforest:ur_ghast",
+            "inTantrum:1": 0
+          },
+          "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
           "requiredItems:9": {
             "0:10": {
               "Count:3": 1,
@@ -4086,9 +5629,10 @@
             "id:8": "draconicevolution:chaos_shard"
           },
           "ismain:1": 1,
-          "name:8": "§6§l§kChaos Guardian",
+          "name:8": "§6§l§kChaos Guardian§r",
           "snd_complete:8": "contenttweaker:questepic",
-          "snd_update:8": "contenttweaker:questepic"
+          "snd_update:8": "contenttweaker:questepic",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 87,
@@ -4300,6 +5844,16 @@
             "id:8": "draconicevolution:chaosguardian"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "draconicevolution:chaos_shard"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -5240,20 +6794,21 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 1,
-          "desc:8": "     While it does not have too much health, this annoying skeletons will constantly try to pick you up and throw you into lava",
+          "desc:8": "     While it does not have too much health, this annoying skeletons will constantly try to pick you up and throw you into lava\n\n§3§lNote: Leaving the bossroom of any planetary dungeon while the boss is still alive will despawn it. You need to defeat the boss before opening its loot chest, otherwise it will be empty, even if you obtained a key from a different dungeon.",
           "icon:10": {
             "Count:3": 1,
             "id:8": "galacticraftcore:key"
           },
           "name:8": "Evolved Skeleton Boss",
           "snd_complete:8": "contenttweaker:questdramatic",
-          "snd_update:8": "contenttweaker:questdramatic"
+          "snd_update:8": "contenttweaker:questdramatic",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 110,
       "rewards:9": {
         "0:10": {
-          "amount:3": 20,
+          "amount:3": 50,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         },
@@ -5428,6 +6983,16 @@
             "id:8": "galacticraftcore:evolved_skeleton_boss"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "galacticraftcore:key"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -5446,13 +7011,14 @@
           },
           "name:8": "Evolved Creeper",
           "snd_complete:8": "contenttweaker:questdramatic",
-          "snd_update:8": "contenttweaker:questdramatic"
+          "snd_update:8": "contenttweaker:questdramatic",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 111,
       "rewards:9": {
         "0:10": {
-          "amount:3": 20,
+          "amount:3": 70,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         },
@@ -5571,7 +7137,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -5625,6 +7193,16 @@
             "id:8": "galacticraftplanets:creeper_boss"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "galacticraftplanets:key"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -5643,13 +7221,14 @@
           },
           "name:8": "Spider Queen",
           "snd_complete:8": "contenttweaker:questdramatic",
-          "snd_update:8": "contenttweaker:questdramatic"
+          "snd_update:8": "contenttweaker:questdramatic",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 112,
       "rewards:9": {
         "0:10": {
-          "amount:3": 20,
+          "amount:3": 90,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         },
@@ -5768,7 +7347,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -5824,6 +7405,16 @@
             "spawned_children:9": {}
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "galacticraftplanets:key_t3"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -11166,7 +12757,8 @@
           },
           "name:8": "Runestone Dungeon Keeper",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 273,
@@ -11357,6 +12949,16 @@
             "id:8": "theaurorian:runestonedungeonkeeper"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "theaurorian:trophykeeper"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -11412,7 +13014,8 @@
           },
           "name:8": "Summoner",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 275,
@@ -11532,7 +13135,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -11591,6 +13196,17 @@
             "id:8": "blue_skies:summoner_illager"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "Damage:2": 6,
+              "id:8": "blue_skies:arcs"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -11679,7 +13295,8 @@
           },
           "name:8": "Alchemist",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 278,
@@ -11861,6 +13478,16 @@
             "id:8": "blue_skies:alchemist_illager"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "blue_skies:arcs"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -11903,14 +13530,15 @@
       ],
       "properties:10": {
         "betterquesting:10": {
-          "desc:8": "     I guess the Pharoh wasnt really dead after all, was he? Can be found in pyramids in the §e§oAtum§r.",
+          "desc:8": "     I guess the Pharoh wasnt really dead after all, was he? Can be found in pyramids in the §e§oAtum§r. Normal torches won\u0027t be enough to summon his §oroyalty§r.\n\n§3§lNote: The Pharaoh can appear in one of 15 variants, indicated by the color of his name, each with unique effects. His name and the artifact you will get after defeating him are not affected by the variant.",
           "icon:10": {
             "Count:3": 1,
             "id:8": "atum:sarcophagus"
           },
           "name:8": "Pharoh",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 280,
@@ -11926,6 +13554,14 @@
           "index:3": 0,
           "target:8": "atum:pharaoh",
           "targetNBT:10": {
+            "AABB:9": {
+              "0:6": -0.30000001192092896,
+              "1:6": 0.0,
+              "2:6": -0.30000001192092896,
+              "3:6": 0.30000001192092896,
+              "4:6": 1.7999999523162842,
+              "5:6": 0.30000001192092896
+            },
             "AbsorptionAmount:5": 0.0,
             "Air:2": 300,
             "ArmorDropChances:9": {
@@ -11942,53 +13578,73 @@
             },
             "Attributes:9": {
               "0:10": {
-                "Base:6": 0.0,
-                "Name:8": "attribute.name.aether.slash"
+                "Base:6": 1.0,
+                "Name:8": "potioncore.projectileDamage"
               },
               "1:10": {
-                "Base:6": 0.0,
-                "Name:8": "attribute.name.aether.pierce"
+                "Base:6": 1.0,
+                "Name:8": "potioncore.magicDamage"
               },
               "2:10": {
-                "Base:6": 0.0,
-                "Name:8": "attribute.name.aether.impact"
+                "Base:6": 1.0,
+                "Name:8": "potioncore.jumpHeight"
               },
               "3:10": {
-                "Base:6": 300.0,
-                "Name:8": "generic.maxHealth"
+                "Base:6": 1.0,
+                "Name:8": "potioncore.damageResistance"
               },
               "4:10": {
                 "Base:6": 0.0,
-                "Name:8": "generic.knockbackResistance"
+                "Name:8": "potioncore.magicShielding"
               },
               "5:10": {
-                "Base:6": 0.3,
-                "Name:8": "generic.movementSpeed"
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.slash"
               },
               "6:10": {
-                "Base:6": 10.0,
-                "Name:8": "generic.armor"
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.pierce"
               },
               "7:10": {
                 "Base:6": 0.0,
-                "Name:8": "generic.armorToughness"
+                "Name:8": "attribute.name.aether.impact"
               },
               "8:10": {
+                "Base:6": 300.0,
+                "Name:8": "generic.maxHealth"
+              },
+              "9:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.knockbackResistance"
+              },
+              "10:10": {
+                "Base:6": 0.3,
+                "Name:8": "generic.movementSpeed"
+              },
+              "11:10": {
+                "Base:6": 10.0,
+                "Name:8": "generic.armor"
+              },
+              "12:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armorToughness"
+              },
+              "13:10": {
                 "Base:6": 1.0,
                 "Name:8": "forge.swimSpeed"
               },
-              "9:10": {
+              "14:10": {
                 "Base:6": 36.0,
                 "Name:8": "generic.followRange"
               },
-              "10:10": {
+              "15:10": {
                 "Base:6": 8.0,
                 "Name:8": "generic.attackDamage"
               }
             },
             "CanPickUpLoot:1": 0,
             "DeathTime:2": 0,
-            "Dimension:3": 17,
+            "Dimension:3": 7,
             "FallDistance:5": 0.0,
             "FallFlying:1": 0,
             "Fire:2": -1,
@@ -11996,7 +13652,9 @@
               "aether:entityinfo:10": {
                 "hasSpawnArea:1": 0
               },
-              "aether:statuseffects:10": {},
+              "aether:statuseffects:10": {
+                "statusEffects:9": {}
+              },
               "cavern:portal_cache:10": {
                 "LastDim:9": {},
                 "LastPos:9": {}
@@ -12007,9 +13665,6 @@
               },
               "dsurround:entityfx:10": {},
               "dsurround:speech:10": {},
-              "enderutilities:entity_portal_cooldown:10": {
-                "LastInPortal:4": 0
-              },
               "thebetweenlands:custom_step_sound:10": {},
               "thebetweenlands:entity_gems:10": {
                 "gems:9": {}
@@ -12024,6 +13679,14 @@
                 "ticks:3": 0
               },
               "tinkertoolleveling:entityxp:9": {},
+              "twilightforest:cap_boss:10": {
+                "homePos:10": {
+                  "X:3": 0,
+                  "Y:3": 0,
+                  "Z:3": 0
+                },
+                "variant:3": -1
+              },
               "twilightforest:cap_shield:10": {
                 "permshields:3": 0,
                 "tempshields:3": 0
@@ -12059,36 +13722,181 @@
               "1:6": 0.0,
               "2:6": 0.0
             },
-            "RelativeAABB:9": {
-              "0:6": -0.30000001192092896,
-              "1:6": 0.0,
-              "2:6": -0.30000001192092896,
-              "3:6": 0.30000001192092896,
-              "4:6": 1.7999999523162842,
-              "5:6": 0.30000001192092896
-            },
             "Rotation:9": {
-              "0:5": 3.4091656,
+              "0:5": 3.3912458,
               "1:5": 0.0
             },
-            "SurgeAABB:9": {
-              "0:6": -0.30000001192092896,
-              "1:6": 0.0,
-              "2:6": -0.30000001192092896,
-              "3:6": 0.30000001192092896,
-              "4:6": 1.7999999523162842,
-              "5:6": 0.30000001192092896
-            },
-            "UUIDLeast:4": -7008869152563795372,
-            "UUIDMost:4": 8422981552061106137,
+            "UUIDLeast:4": -9209807643085530286,
+            "UUIDMost:4": -7119656744828973909,
             "UpdateBlocked:1": 0,
             "Variant:3": 0,
+            "gravityFactor:6": 1.0,
             "id:8": "atum:pharaoh",
             "numeral:3": 0,
             "prefix:3": 0,
             "suffix:3": 0
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "entryLogic:8": "OR",
+          "ignoreNBT:1": 1,
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "atum:anputs_hunger"
+            },
+            "1:10": {
+              "Count:3": 1,
+              "id:8": "atum:anubiss_mercy"
+            },
+            "2:10": {
+              "Count:3": 1,
+              "id:8": "atum:anubiss_wrath"
+            },
+            "3:10": {
+              "Count:3": 1,
+              "id:8": "atum:atums_bounty"
+            },
+            "4:10": {
+              "Count:3": 1,
+              "id:8": "atum:atums_homecoming"
+            },
+            "5:10": {
+              "Count:3": 1,
+              "id:8": "atum:atums_protection"
+            },
+            "6:10": {
+              "Count:3": 1,
+              "id:8": "atum:atums_will"
+            },
+            "7:10": {
+              "Count:3": 1,
+              "id:8": "atum:eyes_of_atum"
+            },
+            "8:10": {
+              "Count:3": 1,
+              "id:8": "atum:body_of_atum"
+            },
+            "9:10": {
+              "Count:3": 1,
+              "id:8": "atum:legs_of_atum"
+            },
+            "10:10": {
+              "Count:3": 1,
+              "id:8": "atum:feet_of_atum"
+            },
+            "11:10": {
+              "Count:3": 1,
+              "id:8": "atum:gebs_grounding"
+            },
+            "12:10": {
+              "Count:3": 1,
+              "id:8": "atum:gebs_might"
+            },
+            "13:10": {
+              "Count:3": 1,
+              "id:8": "atum:gebs_toil"
+            },
+            "14:10": {
+              "Count:3": 1,
+              "id:8": "atum:horuss_ascension"
+            },
+            "15:10": {
+              "Count:3": 1,
+              "id:8": "atum:horuss_soaring"
+            },
+            "16:10": {
+              "Count:3": 1,
+              "id:8": "atum:isis_healing"
+            },
+            "17:10": {
+              "Count:3": 1,
+              "id:8": "atum:montus_blast"
+            },
+            "18:10": {
+              "Count:3": 1,
+              "id:8": "atum:montus_strike"
+            },
+            "19:10": {
+              "Count:3": 1,
+              "id:8": "atum:nuits_duality"
+            },
+            "20:10": {
+              "Count:3": 1,
+              "id:8": "atum:nuits_ire"
+            },
+            "21:10": {
+              "Count:3": 1,
+              "id:8": "atum:nuits_quarter"
+            },
+            "22:10": {
+              "Count:3": 1,
+              "id:8": "atum:nuits_vanishing"
+            },
+            "23:10": {
+              "Count:3": 1,
+              "id:8": "atum:ptahs_decadence"
+            },
+            "24:10": {
+              "Count:3": 1,
+              "id:8": "atum:ptahs_undoing"
+            },
+            "25:10": {
+              "Count:3": 1,
+              "id:8": "atum:halo_of_ra"
+            },
+            "26:10": {
+              "Count:3": 1,
+              "id:8": "atum:body_of_ra"
+            },
+            "27:10": {
+              "Count:3": 1,
+              "id:8": "atum:legs_of_ra"
+            },
+            "28:10": {
+              "Count:3": 1,
+              "id:8": "atum:feet_of_ra"
+            },
+            "29:10": {
+              "Count:3": 1,
+              "id:8": "atum:ras_fury"
+            },
+            "30:10": {
+              "Count:3": 1,
+              "id:8": "atum:seths_sting"
+            },
+            "31:10": {
+              "Count:3": 1,
+              "id:8": "atum:seths_venom"
+            },
+            "32:10": {
+              "Count:3": 1,
+              "id:8": "atum:shus_breath"
+            },
+            "33:10": {
+              "Count:3": 1,
+              "id:8": "atum:shus_exile"
+            },
+            "34:10": {
+              "Count:3": 1,
+              "id:8": "atum:shus_swiftness"
+            },
+            "35:10": {
+              "Count:3": 1,
+              "id:8": "atum:tefnuts_blessing"
+            },
+            "36:10": {
+              "Count:3": 1,
+              "id:8": "atum:tefnuts_call"
+            },
+            "37:10": {
+              "Count:3": 1,
+              "id:8": "atum:tefnuts_rain"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -12965,7 +14773,8 @@
           },
           "name:8": "Crazy Zombie",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 301,
@@ -13145,6 +14954,16 @@
             "id:8": "cavern:crazy_zombie"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "contenttweaker:crazy_zombie_essence"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -13166,7 +14985,8 @@
           },
           "name:8": "Crazy Skeleton",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 302,
@@ -13341,6 +15161,16 @@
             "id:8": "cavern:crazy_skeleton"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "contenttweaker:crazy_skeleton_essence"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -13362,7 +15192,8 @@
           },
           "name:8": "Crazy Spider",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 303,
@@ -13537,6 +15368,16 @@
             "id:8": "cavern:crazy_spider"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "contenttweaker:crazy_spider_essence"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -13558,7 +15399,8 @@
           },
           "name:8": "Crazy Creeper",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 304,
@@ -13736,6 +15578,16 @@
             "ignited:1": 0
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "contenttweaker:crazy_creeper_essence"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -17312,7 +19164,8 @@
           },
           "name:8": "Guardian of Gaia",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 407,
@@ -17427,7 +19280,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -17489,6 +19344,17 @@
             "sourcesZ:3": 0
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "Damage:2": 5,
+              "id:8": "botania:manaresource"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -19507,13 +21373,14 @@
           },
           "name:8": "Evolved Fire Bat",
           "snd_complete:8": "contenttweaker:questdramatic",
-          "snd_update:8": "contenttweaker:questdramatic"
+          "snd_update:8": "contenttweaker:questdramatic",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 458,
       "rewards:9": {
         "0:10": {
-          "amount:3": 20,
+          "amount:3": 150,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         },
@@ -19706,6 +21573,16 @@
             "id:8": "extraplanets:extraplanets.evolvedfirebatboss"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "extraplanets:t5key"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -26255,13 +28132,14 @@
           },
           "name:8": "Dreadful Peat Mummy",
           "snd_complete:8": "contenttweaker:questdramatic",
-          "snd_update:8": "contenttweaker:questdramatic"
+          "snd_update:8": "contenttweaker:questdramatic",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 642,
       "rewards:9": {
         "0:10": {
-          "amount:3": 20,
+          "amount:3": 30,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         },
@@ -26460,6 +28338,17 @@
             "spawningState:3": 0
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "ignoreNBT:1": 1,
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "thebetweenlands:ring_of_summoning"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -26470,20 +28359,21 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 1,
-          "desc:8": "     This menace, a living coagulation of sludge is your final trial within the pit of decay at the bottom of a sludgeon.",
+          "desc:8": "     This menace, a living coagulation of sludge is your final trial within the pit of decay at the bottom of a sludgeon.\n\n§3§lNote: The Ring currently doesn\u0027t work near activated Stargates.",
           "icon:10": {
             "Count:3": 1,
             "id:8": "thebetweenlands:sludge_ball"
           },
           "name:8": "Sludge Menace",
           "snd_complete:8": "contenttweaker:questdramatic",
-          "snd_update:8": "contenttweaker:questdramatic"
+          "snd_update:8": "contenttweaker:questdramatic",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 643,
       "rewards:9": {
         "0:10": {
-          "amount:3": 20,
+          "amount:3": 50,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -26670,6 +28560,17 @@
             "id:8": "thebetweenlands:sludge_menace"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "ignoreNBT:1": 1,
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "thebetweenlands:ring_of_dispersion"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -26680,20 +28581,21 @@
       "properties:10": {
         "betterquesting:10": {
           "autoclaim:1": 1,
-          "desc:8": "     The overseer and ruler of the ruined swamp realm of The Betweenlands is this thing what caused the recent §6§l§oDimensional Shift§r? Can only be found at the top of the elusive Wight\u0027s Fortress.",
+          "desc:8": "     The Stupid Sphere Thing - formerly called Primordial Malevolence - is the overseer and ruler of the ruined swamp realm of The Betweenlands. Is this thing what caused the recent §6§l§oDimensional Shift§r? Can only be found at the top of the elusive Wight\u0027s Fortress.",
           "icon:10": {
             "Count:3": 1,
             "id:8": "thebetweenlands:wight_heart"
           },
-          "name:8": "Primordial Malevolence",
+          "name:8": "Stupid Sphere Thing",
           "snd_complete:8": "contenttweaker:questdramatic",
-          "snd_update:8": "contenttweaker:questdramatic"
+          "snd_update:8": "contenttweaker:questdramatic",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 644,
       "rewards:9": {
         "0:10": {
-          "amount:3": 20,
+          "amount:3": 40,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         },
@@ -26880,6 +28782,17 @@
             "wightSpawnTicks:3": -1
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "ignoreNBT:1": 1,
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "thebetweenlands:ring_of_recruitment"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -32516,7 +34429,7 @@
       "questID:3": 773,
       "rewards:9": {
         "0:10": {
-          "amount:3": 20,
+          "amount:3": 50,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -35857,13 +37770,14 @@
           },
           "name:8": "Evolved Magma Cube Boss",
           "snd_complete:8": "contenttweaker:questdramatic",
-          "snd_update:8": "contenttweaker:questdramatic"
+          "snd_update:8": "contenttweaker:questdramatic",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 869,
       "rewards:9": {
         "0:10": {
-          "amount:3": 20,
+          "amount:3": 90,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -35976,7 +37890,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -36032,6 +37948,16 @@
             "wasOnGround:1": 0
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "extraplanets:t4key"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -37245,7 +39171,7 @@
       "questID:3": 903,
       "rewards:9": {
         "0:10": {
-          "amount:3": 40,
+          "amount:3": 75,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -38686,13 +40612,14 @@
           },
           "name:8": "Smash",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 950,
       "rewards:9": {
         "0:10": {
-          "amount:3": 20,
+          "amount:3": 75,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -38805,7 +40732,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -38859,6 +40788,16 @@
             "id:8": "aoa3:smash"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:smash_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -39065,13 +41004,14 @@
           },
           "name:8": "Corallus",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 956,
       "rewards:9": {
         "0:10": {
-          "amount:3": 20,
+          "amount:3": 75,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -39240,6 +41180,16 @@
             "id:8": "aoa3:corallus"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:corallus_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -39433,13 +41383,14 @@
           },
           "name:8": "King BamBamBam",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 962,
       "rewards:9": {
         "0:10": {
-          "amount:3": 30,
+          "amount:3": 75,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -39552,7 +41503,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -39606,6 +41559,16 @@
             "id:8": "aoa3:king_bambambam"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:king_bambambam_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -39622,13 +41585,14 @@
           },
           "name:8": "Nethengeic Wither",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 963,
       "rewards:9": {
         "0:10": {
-          "amount:3": 30,
+          "amount:3": 75,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -39741,7 +41705,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -39795,6 +41761,16 @@
             "id:8": "aoa3:nethengeic_wither"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:nethengeic_wither_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -40180,13 +42156,14 @@
           },
           "name:8": "Hive King",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 974,
       "rewards:9": {
         "0:10": {
-          "amount:3": 30,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -40196,6 +42173,14 @@
           "index:3": 0,
           "target:8": "aoa3:hive_king",
           "targetNBT:10": {
+            "AABB:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0,
+              "3:6": 0.0,
+              "4:6": 0.0,
+              "5:6": 0.0
+            },
             "AbsorptionAmount:5": 0.0,
             "Air:2": 300,
             "ArmorDropChances:9": {
@@ -40212,53 +42197,73 @@
             },
             "Attributes:9": {
               "0:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.projectileDamage"
+              },
+              "1:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.magicDamage"
+              },
+              "2:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.jumpHeight"
+              },
+              "3:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.damageResistance"
+              },
+              "4:10": {
+                "Base:6": 0.0,
+                "Name:8": "potioncore.magicShielding"
+              },
+              "5:10": {
                 "Base:6": 0.0,
                 "Name:8": "attribute.name.aether.slash"
               },
-              "1:10": {
+              "6:10": {
                 "Base:6": 0.0,
                 "Name:8": "attribute.name.aether.pierce"
               },
-              "2:10": {
+              "7:10": {
                 "Base:6": 0.0,
                 "Name:8": "attribute.name.aether.impact"
               },
-              "3:10": {
+              "8:10": {
                 "Base:6": 2500.0,
                 "Name:8": "generic.maxHealth"
               },
-              "4:10": {
+              "9:10": {
                 "Base:6": 0.8,
                 "Name:8": "generic.knockbackResistance"
               },
-              "5:10": {
+              "10:10": {
                 "Base:6": 0.2875,
                 "Name:8": "generic.movementSpeed"
               },
-              "6:10": {
+              "11:10": {
                 "Base:6": 0.0,
                 "Name:8": "generic.armor"
               },
-              "7:10": {
+              "12:10": {
                 "Base:6": 0.0,
                 "Name:8": "generic.armorToughness"
               },
-              "8:10": {
+              "13:10": {
                 "Base:6": 1.0,
                 "Name:8": "forge.swimSpeed"
               },
-              "9:10": {
+              "14:10": {
                 "Base:6": 16.0,
                 "Name:8": "generic.followRange"
               },
-              "10:10": {
+              "15:10": {
                 "Base:6": 20.0,
                 "Name:8": "generic.attackDamage"
               }
             },
             "CanPickUpLoot:1": 0,
             "DeathTime:2": 0,
-            "Dimension:3": 0,
+            "Dimension:3": 17,
             "FallDistance:5": 0.0,
             "FallFlying:1": 0,
             "Fire:2": -1,
@@ -40266,7 +42271,9 @@
               "aether:entityinfo:10": {
                 "hasSpawnArea:1": 0
               },
-              "aether:statuseffects:10": {},
+              "aether:statuseffects:10": {
+                "statusEffects:9": {}
+              },
               "cavern:portal_cache:10": {
                 "LastDim:9": {},
                 "LastPos:9": {}
@@ -40277,9 +42284,6 @@
               },
               "dsurround:entityfx:10": {},
               "dsurround:speech:10": {},
-              "enderutilities:entity_portal_cooldown:10": {
-                "LastInPortal:4": 0
-              },
               "thebetweenlands:custom_step_sound:10": {},
               "thebetweenlands:entity_gems:10": {
                 "gems:9": {}
@@ -40294,6 +42298,14 @@
                 "ticks:3": 0
               },
               "tinkertoolleveling:entityxp:9": {},
+              "twilightforest:cap_boss:10": {
+                "homePos:10": {
+                  "X:3": 0,
+                  "Y:3": 0,
+                  "Z:3": 0
+                },
+                "variant:3": -1
+              },
               "twilightforest:cap_shield:10": {
                 "permshields:3": 0,
                 "tempshields:3": 0
@@ -40329,32 +42341,27 @@
               "1:6": 0.0,
               "2:6": 0.0
             },
-            "RelativeAABB:9": {
-              "0:6": 0.0,
-              "1:6": 0.0,
-              "2:6": 0.0,
-              "3:6": 0.0,
-              "4:6": 0.0,
-              "5:6": 0.0
-            },
             "Rotation:9": {
-              "0:5": 5.2237287,
+              "0:5": 1.5903466,
               "1:5": 0.0
             },
-            "SurgeAABB:9": {
-              "0:6": 0.0,
-              "1:6": 0.0,
-              "2:6": 0.0,
-              "3:6": 0.0,
-              "4:6": 0.0,
-              "5:6": 0.0
-            },
-            "UUIDLeast:4": -5967733046696150008,
-            "UUIDMost:4": 4126459529513484775,
+            "UUIDLeast:4": -8736709753734557931,
+            "UUIDMost:4": -5760184679398554054,
             "UpdateBlocked:1": 0,
+            "gravityFactor:6": 1.0,
             "id:8": "aoa3:hive_king"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:hive_king_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -40371,13 +42378,14 @@
           },
           "name:8": "Baroness",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 975,
       "rewards:9": {
         "0:10": {
-          "amount:3": 30,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -40490,7 +42498,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -40544,6 +42554,16 @@
             "id:8": "aoa3:baroness"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:baroness_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -40833,13 +42853,14 @@
           },
           "name:8": "MechBot",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 983,
       "rewards:9": {
         "0:10": {
-          "amount:3": 40,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -40952,7 +42973,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -41006,6 +43029,16 @@
             "id:8": "aoa3:mechbot"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:mechbot_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -41022,13 +43055,14 @@
           },
           "name:8": "Silverfoot",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 984,
       "rewards:9": {
         "0:10": {
-          "amount:3": 40,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -41141,7 +43175,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -41195,6 +43231,16 @@
             "id:8": "aoa3:silverfoot"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:silverfoot_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -41517,13 +43563,14 @@
           },
           "name:8": "C.R.E.E.P",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 993,
       "rewards:9": {
         "0:10": {
-          "amount:3": 30,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -41636,7 +43683,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -41690,6 +43739,16 @@
             "id:8": "aoa3:creep"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:creep_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -41806,13 +43865,14 @@
           },
           "name:8": "Kror",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 997,
       "rewards:9": {
         "0:10": {
-          "amount:3": 30,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -41981,6 +44041,16 @@
             "id:8": "aoa3:kror"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:kror_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -42111,13 +44181,14 @@
           },
           "name:8": "Graw",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1001,
       "rewards:9": {
         "0:10": {
-          "amount:3": 30,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -42226,7 +44297,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -42280,6 +44353,16 @@
             "id:8": "aoa3:graw"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:graw_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -42410,13 +44493,14 @@
           },
           "name:8": "Tyrosaur",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1005,
       "rewards:9": {
         "0:10": {
-          "amount:3": 30,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -42529,7 +44613,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -42583,6 +44669,16 @@
             "id:8": "aoa3:tyrosaur"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:tyrosaur_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -42599,13 +44695,14 @@
           },
           "name:8": "Skeletron",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1006,
       "rewards:9": {
         "0:10": {
-          "amount:3": 30,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -42718,7 +44815,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -42772,6 +44871,16 @@
             "id:8": "aoa3:skeletron"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:skeletron_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -42962,13 +45071,14 @@
           },
           "name:8": "Shadowlord",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1012,
       "rewards:9": {
         "0:10": {
-          "amount:3": 40,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -43081,7 +45191,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -43135,6 +45247,16 @@
             "id:8": "aoa3:shadowlord"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:shadowlord_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -43151,13 +45273,14 @@
           },
           "name:8": "Elusive",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1013,
       "rewards:9": {
         "0:10": {
-          "amount:3": 40,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -43270,7 +45393,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -43324,6 +45449,16 @@
             "id:8": "aoa3:elusive"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:elusive_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -43561,20 +45696,21 @@
       ],
       "properties:10": {
         "betterquesting:10": {
-          "desc:8": "     Can be summoned by eating a§5 §oTreat Bag§r anywhere within the realm of §d§oCandyland§r.\n\n§4§lNote:§r§4 He can only be damaged with a staff.",
+          "desc:8": "     Can be summoned by eating a§5 §oTreat Bag§r anywhere within the realm of §d§oCandyland§r.\n\n§4§lNote:§r§4 He can only be damaged with staves. The element depends on his feet.",
           "icon:10": {
             "Count:3": 1,
             "id:8": "aoa3:ornate_cotton_candor_statue"
           },
           "name:8": "Cotton Candor",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1020,
       "rewards:9": {
         "0:10": {
-          "amount:3": 40,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -43683,7 +45819,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -43737,6 +45875,16 @@
             "id:8": "aoa3:cotton_candor"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:cotton_candor_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -43746,20 +45894,21 @@
       ],
       "properties:10": {
         "betterquesting:10": {
-          "desc:8": "     Can be summoned by using§5 §oPetals§r on a §d§oViocorne Shrine§r.",
+          "desc:8": "     Can be summoned by using§5 §oPetals§r on a §d§oVinocorne Shrine§r.",
           "icon:10": {
             "Count:3": 1,
             "id:8": "aoa3:ornate_vinocorne_statue"
           },
           "name:8": "Vinocorne",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1021,
       "rewards:9": {
         "0:10": {
-          "amount:3": 40,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -43872,7 +46021,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -43926,6 +46077,16 @@
             "id:8": "aoa3:vinocorne"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:vinocorne_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -44281,13 +46442,14 @@
           },
           "name:8": "Gyro",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1031,
       "rewards:9": {
         "0:10": {
-          "amount:3": 40,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -44396,7 +46558,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -44450,6 +46614,16 @@
             "id:8": "aoa3:gyro"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:gyro_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -44466,13 +46640,14 @@
           },
           "name:8": "Rockrider",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1032,
       "rewards:9": {
         "0:10": {
-          "amount:3": 40,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -44585,7 +46760,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -44639,6 +46816,16 @@
             "id:8": "aoa3:rock_rider"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:rockrider_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -44655,7 +46842,8 @@
           },
           "name:8": "Four Guardians",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1033,
@@ -44671,6 +46859,14 @@
           "index:3": 0,
           "target:8": "aoa3:blue_guardian",
           "targetNBT:10": {
+            "AABB:9": {
+              "0:6": -0.75,
+              "1:6": 0.0,
+              "2:6": -0.75,
+              "3:6": 0.75,
+              "4:6": 2.625,
+              "5:6": 0.75
+            },
             "AbsorptionAmount:5": 0.0,
             "Air:2": 300,
             "ArmorDropChances:9": {
@@ -44687,46 +46883,66 @@
             },
             "Attributes:9": {
               "0:10": {
-                "Base:6": 0.0,
-                "Name:8": "attribute.name.aether.slash"
+                "Base:6": 1.0,
+                "Name:8": "potioncore.projectileDamage"
               },
               "1:10": {
-                "Base:6": 0.0,
-                "Name:8": "attribute.name.aether.pierce"
+                "Base:6": 1.0,
+                "Name:8": "potioncore.magicDamage"
               },
               "2:10": {
-                "Base:6": 0.0,
-                "Name:8": "attribute.name.aether.impact"
+                "Base:6": 1.0,
+                "Name:8": "potioncore.jumpHeight"
               },
               "3:10": {
-                "Base:6": 750.0,
-                "Name:8": "generic.maxHealth"
+                "Base:6": 1.0,
+                "Name:8": "potioncore.damageResistance"
               },
               "4:10": {
                 "Base:6": 0.0,
-                "Name:8": "generic.knockbackResistance"
+                "Name:8": "potioncore.magicShielding"
               },
               "5:10": {
-                "Base:6": 0.207,
-                "Name:8": "generic.movementSpeed"
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.slash"
               },
               "6:10": {
                 "Base:6": 0.0,
-                "Name:8": "generic.armor"
+                "Name:8": "attribute.name.aether.pierce"
               },
               "7:10": {
                 "Base:6": 0.0,
-                "Name:8": "generic.armorToughness"
+                "Name:8": "attribute.name.aether.impact"
               },
               "8:10": {
+                "Base:6": 750.0,
+                "Name:8": "generic.maxHealth"
+              },
+              "9:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.knockbackResistance"
+              },
+              "10:10": {
+                "Base:6": 0.207,
+                "Name:8": "generic.movementSpeed"
+              },
+              "11:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armor"
+              },
+              "12:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armorToughness"
+              },
+              "13:10": {
                 "Base:6": 1.0,
                 "Name:8": "forge.swimSpeed"
               },
-              "9:10": {
+              "14:10": {
                 "Base:6": 24.0,
                 "Name:8": "generic.followRange"
               },
-              "10:10": {
+              "15:10": {
                 "Base:6": 2.0,
                 "Name:8": "generic.attackDamage"
               }
@@ -44741,7 +46957,9 @@
               "aether:entityinfo:10": {
                 "hasSpawnArea:1": 0
               },
-              "aether:statuseffects:10": {},
+              "aether:statuseffects:10": {
+                "statusEffects:9": {}
+              },
               "cavern:portal_cache:10": {
                 "LastDim:9": {},
                 "LastPos:9": {}
@@ -44752,9 +46970,6 @@
               },
               "dsurround:entityfx:10": {},
               "dsurround:speech:10": {},
-              "enderutilities:entity_portal_cooldown:10": {
-                "LastInPortal:4": 0
-              },
               "thebetweenlands:custom_step_sound:10": {},
               "thebetweenlands:entity_gems:10": {
                 "gems:9": {}
@@ -44769,12 +46984,22 @@
                 "ticks:3": 0
               },
               "tinkertoolleveling:entityxp:9": {},
+              "twilightforest:cap_boss:10": {
+                "homePos:10": {
+                  "X:3": 0,
+                  "Y:3": 0,
+                  "Z:3": 0
+                },
+                "variant:3": -1
+              },
               "twilightforest:cap_shield:10": {
                 "permshields:3": 0,
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -44802,29 +47027,14 @@
               "1:6": 0.0,
               "2:6": 0.0
             },
-            "RelativeAABB:9": {
-              "0:6": -0.30000001192092896,
-              "1:6": 0.0,
-              "2:6": -0.30000001192092896,
-              "3:6": 1.199999988079071,
-              "4:6": 2.625,
-              "5:6": 1.199999988079071
-            },
             "Rotation:9": {
               "0:5": 0.44604233,
               "1:5": 0.0
             },
-            "SurgeAABB:9": {
-              "0:6": -0.30000001192092896,
-              "1:6": 0.0,
-              "2:6": -0.30000001192092896,
-              "3:6": 1.199999988079071,
-              "4:6": 2.625,
-              "5:6": 1.199999988079071
-            },
             "UUIDLeast:4": -7331459428228310251,
             "UUIDMost:4": -4973166960911433082,
             "UpdateBlocked:1": 0,
+            "gravityFactor:6": 1.0,
             "id:8": "aoa3:blue_guardian"
           },
           "taskID:8": "bq_standard:hunt"
@@ -44936,7 +47146,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -45098,7 +47310,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -45260,7 +47474,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -45314,6 +47530,16 @@
             "id:8": "aoa3:yellow_guardian"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "4:10": {
+          "index:3": 4,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:guardian_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -45577,7 +47803,10 @@
     },
     "1040:10": {
       "preRequisites:11": [
-        1033
+        81686143,
+        287457859,
+        783863246,
+        1161281890
       ],
       "properties:10": {
         "betterquesting:10": {
@@ -45590,6 +47819,7 @@
             "id:8": "aoa3:guardians_sword"
           },
           "name:8": "Guardian\u0027s Sword",
+          "questlogic:8": "OR",
           "snd_complete:8": "contenttweaker:questcommon",
           "snd_update:8": "contenttweaker:questcommon",
           "visibility:8": "COMPLETED"
@@ -45622,11 +47852,11 @@
     },
     "1041:10": {
       "preRequisites:11": [
-        1033
+        81686143
       ],
       "properties:10": {
         "betterquesting:10": {
-          "desc:8": "     It seems to have dropped from the §4§oFour Guardians§r...",
+          "desc:8": "     It seems to have dropped from the §4§oBlue Guardian§r...",
           "icon:10": {
             "Count:3": 1,
             "id:8": "aoa3:frosticator",
@@ -45667,11 +47897,11 @@
     },
     "1042:10": {
       "preRequisites:11": [
-        1033
+        783863246
       ],
       "properties:10": {
         "betterquesting:10": {
-          "desc:8": "     It seems to have dropped from the §4§oFour Guardians§r...",
+          "desc:8": "     It seems to have dropped from the §4§oGreen Guardian§r...",
           "icon:10": {
             "Count:3": 1,
             "id:8": "aoa3:germinator",
@@ -45712,11 +47942,11 @@
     },
     "1043:10": {
       "preRequisites:11": [
-        1033
+        1161281890
       ],
       "properties:10": {
         "betterquesting:10": {
-          "desc:8": "     It seems to have dropped from the §4§oFour Guardians§r...",
+          "desc:8": "     It seems to have dropped from the §4§oRed Guardian§r...",
           "icon:10": {
             "Count:3": 1,
             "id:8": "aoa3:dragilator",
@@ -45757,11 +47987,11 @@
     },
     "1044:10": {
       "preRequisites:11": [
-        1033
+        287457859
       ],
       "properties:10": {
         "betterquesting:10": {
-          "desc:8": "     It seems to have dropped from the §4§oFour Guardians§r...",
+          "desc:8": "     It seems to have dropped from the §4§oYellow Guardian§r...",
           "icon:10": {
             "Count:3": 1,
             "id:8": "aoa3:electinator",
@@ -45968,13 +48198,14 @@
           },
           "name:8": "Crystocore",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1049,
       "rewards:9": {
         "0:10": {
-          "amount:3": 40,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -46087,7 +48318,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -46141,6 +48374,16 @@
             "id:8": "aoa3:crystocore"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:crystocore_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -46355,13 +48598,14 @@
           },
           "name:8": "King Shroomus",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1056,
       "rewards:9": {
         "0:10": {
-          "amount:3": 40,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -46474,7 +48718,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -46528,6 +48774,16 @@
             "id:8": "aoa3:king_shroomus"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:king_shroomus_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -46544,7 +48800,8 @@
           },
           "name:8": "Antlion Overlord",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1057,
@@ -46743,6 +49000,16 @@
             "spawnPointZ:3": 0
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "erebus:antlion_egg"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -46915,13 +49182,14 @@
           },
           "name:8": "Coniferon",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1062,
       "rewards:9": {
         "0:10": {
-          "amount:3": 50,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -47034,7 +49302,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -47088,6 +49358,16 @@
             "id:8": "aoa3:coniferon"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:coniferon_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -47104,13 +49384,14 @@
           },
           "name:8": "Horon",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1063,
       "rewards:9": {
         "0:10": {
-          "amount:3": 50,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -47223,7 +49504,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -47277,6 +49560,16 @@
             "id:8": "aoa3:horon"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:horon_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -47293,13 +49586,14 @@
           },
           "name:8": "Goldorth",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1064,
       "rewards:9": {
         "0:10": {
-          "amount:3": 50,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -47412,7 +49706,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -47466,6 +49762,16 @@
             "id:8": "aoa3:goldorth"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:goldorth_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -47482,13 +49788,14 @@
           },
           "name:8": "Penumbra",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1065,
       "rewards:9": {
         "0:10": {
-          "amount:3": 50,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -47601,7 +49908,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -47655,6 +49964,16 @@
             "id:8": "aoa3:penumbra"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:penumbra_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -48231,13 +50550,14 @@
           },
           "name:8": "Klobber",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1080,
       "rewards:9": {
         "0:10": {
-          "amount:3": 50,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -48350,7 +50670,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -48404,6 +50726,16 @@
             "id:8": "aoa3:klobber"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:klobber_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -48420,13 +50752,14 @@
           },
           "name:8": "Proshield",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1081,
       "rewards:9": {
         "0:10": {
-          "amount:3": 50,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -48539,7 +50872,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -48593,6 +50928,16 @@
             "id:8": "aoa3:proshield"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:proshield_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -48609,13 +50954,14 @@
           },
           "name:8": "Mirage",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1082,
       "rewards:9": {
         "0:10": {
-          "amount:3": 50,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -48728,7 +51074,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -48782,6 +51130,16 @@
             "id:8": "aoa3:mirage"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:mirage_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -48798,13 +51156,14 @@
           },
           "name:8": "Flash",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1083,
       "rewards:9": {
         "0:10": {
-          "amount:3": 50,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -48917,7 +51276,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -48971,6 +51332,16 @@
             "id:8": "aoa3:flash"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:flash_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -49077,13 +51448,14 @@
           },
           "name:8": "Bane",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1087,
       "rewards:9": {
         "0:10": {
-          "amount:3": 50,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -49196,7 +51568,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -49250,6 +51624,16 @@
             "id:8": "aoa3:bane"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:bane_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -49266,7 +51650,8 @@
           },
           "name:8": "Primordial Five",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1088,
@@ -49385,7 +51770,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -49547,7 +51934,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -49709,7 +52098,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -49871,7 +52262,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -50033,7 +52426,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -50215,7 +52610,7 @@
     },
     "1092:10": {
       "preRequisites:11": [
-        1088
+        1260129780
       ],
       "properties:10": {
         "betterquesting:10": {
@@ -50254,7 +52649,7 @@
     },
     "1093:10": {
       "preRequisites:11": [
-        1088
+        1260129780
       ],
       "properties:10": {
         "betterquesting:10": {
@@ -50293,7 +52688,7 @@
     },
     "1094:10": {
       "preRequisites:11": [
-        1088
+        1260129780
       ],
       "properties:10": {
         "betterquesting:10": {
@@ -50403,13 +52798,14 @@
           },
           "name:8": "Hydrolisk",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1097,
       "rewards:9": {
         "0:10": {
-          "amount:3": 50,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -50522,7 +52918,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -50576,6 +52974,16 @@
             "id:8": "aoa3:hydrolisk"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:hydrolisk_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -50592,13 +53000,14 @@
           },
           "name:8": "Dracyon",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1098,
       "rewards:9": {
         "0:10": {
-          "amount:3": 50,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -50711,7 +53120,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -50765,6 +53176,16 @@
             "id:8": "aoa3:dracyon"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:dracyon_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -51051,21 +53472,16 @@
           },
           "name:8": "Visualent",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1106,
       "rewards:9": {
         "0:10": {
-          "amount:3": 50,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
-        },
-        "1:10": {
-          "command:8": "gamestage silentadd @s tfourstargate",
-          "description:8": "Run a command script",
-          "index:3": 1,
-          "rewardID:8": "bq_standard:command"
         }
       },
       "tasks:9": {
@@ -51176,7 +53592,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -51230,6 +53648,16 @@
             "id:8": "aoa3:visualent"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:visualent_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -51246,13 +53674,14 @@
           },
           "name:8": "Clunkhead",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1107,
       "rewards:9": {
         "0:10": {
-          "amount:3": 50,
+          "amount:3": 100,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -51365,7 +53794,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -51419,6 +53850,16 @@
             "id:8": "aoa3:clunkhead"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:clunkhead_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -51708,21 +54149,20 @@
       "properties:10": {
         "betterquesting:10": {
           "desc:8": "     Can be summoned by using an §5§oAncient Ring§r on a §d§oCraexxeus Altar§r.",
-          "frame:8": "GATE",
           "icon:10": {
             "Count:3": 1,
-            "id:8": "aoa3:ornate_xxeus_statue"
+            "id:8": "aoa3:ornate_craexxeus_statue"
           },
-          "ismain:1": 1,
           "name:8": "Craexxeus",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1115,
       "rewards:9": {
         "0:10": {
-          "amount:3": 75,
+          "amount:3": 95,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -51889,184 +54329,28 @@
           "taskID:8": "bq_standard:hunt"
         },
         "1:10": {
-          "index:3": 1,
-          "target:8": "aoa3:xxeus",
-          "targetNBT:10": {
-            "AbsorptionAmount:5": 0.0,
-            "Air:2": 300,
-            "ArmorDropChances:9": {
-              "0:5": 0.085,
-              "1:5": 0.085,
-              "2:5": 0.085,
-              "3:5": 0.085
-            },
-            "ArmorItems:9": {
-              "0:10": {},
-              "1:10": {},
-              "2:10": {},
-              "3:10": {}
-            },
-            "Attributes:9": {
-              "0:10": {
-                "Base:6": 0.0,
-                "Name:8": "attribute.name.aether.slash"
-              },
-              "1:10": {
-                "Base:6": 0.0,
-                "Name:8": "attribute.name.aether.pierce"
-              },
-              "2:10": {
-                "Base:6": 0.0,
-                "Name:8": "attribute.name.aether.impact"
-              },
-              "3:10": {
-                "Base:6": 3000.0,
-                "Name:8": "generic.maxHealth"
-              },
-              "4:10": {
-                "Base:6": 1.0,
-                "Name:8": "generic.knockbackResistance"
-              },
-              "5:10": {
-                "Base:6": 0.329,
-                "Name:8": "generic.movementSpeed"
-              },
-              "6:10": {
-                "Base:6": 0.0,
-                "Name:8": "generic.armor"
-              },
-              "7:10": {
-                "Base:6": 0.0,
-                "Name:8": "generic.armorToughness"
-              },
-              "8:10": {
-                "Base:6": 1.0,
-                "Name:8": "forge.swimSpeed"
-              },
-              "9:10": {
-                "Base:6": 16.0,
-                "Name:8": "generic.followRange"
-              },
-              "10:10": {
-                "Base:6": 25.0,
-                "Name:8": "generic.attackDamage"
-              }
-            },
-            "CanPickUpLoot:1": 0,
-            "DeathTime:2": 0,
-            "Dimension:3": 0,
-            "FallDistance:5": 0.0,
-            "FallFlying:1": 0,
-            "Fire:2": -1,
-            "ForgeCaps:10": {
-              "aether:entityinfo:10": {
-                "hasSpawnArea:1": 0
-              },
-              "aether:statuseffects:10": {},
-              "cavern:portal_cache:10": {
-                "LastDim:9": {},
-                "LastPos:9": {}
-              },
-              "dsurround:data:10": {
-                "a:1": 0,
-                "f:1": 0
-              },
-              "dsurround:entityfx:10": {},
-              "dsurround:speech:10": {},
-              "enderutilities:entity_portal_cooldown:10": {
-                "LastInPortal:4": 0
-              },
-              "thebetweenlands:custom_step_sound:10": {},
-              "thebetweenlands:entity_gems:10": {
-                "gems:9": {}
-              },
-              "thebetweenlands:equipment:10": {
-                "amuletSlots:3": 1
-              },
-              "thebetweenlands:puppet:10": {
-                "guard:1": 0,
-                "recruitmentCost:3": 0,
-                "stay:1": 0,
-                "ticks:3": 0
-              },
-              "tinkertoolleveling:entityxp:9": {},
-              "twilightforest:cap_shield:10": {
-                "permshields:3": 0,
-                "tempshields:3": 0
-              }
-            },
-            "ForgeData:10": {
-              "isFakeEntityForMoBends:1": 1
-            },
-            "HandDropChances:9": {
-              "0:5": 0.085,
-              "1:5": 0.085
-            },
-            "HandItems:9": {
-              "0:10": {},
-              "1:10": {}
-            },
-            "Health:5": 3000.0,
-            "HurtByTimestamp:3": 0,
-            "HurtTime:2": 0,
-            "Invulnerable:1": 0,
-            "Leashed:1": 0,
-            "LeftHanded:1": 0,
-            "Motion:9": {
-              "0:6": 0.0,
-              "1:6": 0.0,
-              "2:6": 0.0
-            },
-            "OnGround:1": 0,
-            "PersistenceRequired:1": 0,
-            "PortalCooldown:3": 0,
-            "Pos:9": {
-              "0:6": 0.0,
-              "1:6": 0.0,
-              "2:6": 0.0
-            },
-            "RelativeAABB:9": {
-              "0:6": -0.30000001192092896,
-              "1:6": 0.0,
-              "2:6": -0.30000001192092896,
-              "3:6": 0.699999988079071,
-              "4:6": 3.125,
-              "5:6": 0.699999988079071
-            },
-            "Rotation:9": {
-              "0:5": 2.8397744,
-              "1:5": 0.0
-            },
-            "SurgeAABB:9": {
-              "0:6": -0.30000001192092896,
-              "1:6": 0.0,
-              "2:6": -0.30000001192092896,
-              "3:6": 0.699999988079071,
-              "4:6": 3.125,
-              "5:6": 0.699999988079071
-            },
-            "UUIDLeast:4": -7278092987340621142,
-            "UUIDMost:4": -4521979021923038321,
-            "UpdateBlocked:1": 0,
-            "id:8": "aoa3:xxeus"
+          "index:3": 2,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:craexxeus_statue"
+            }
           },
-          "taskID:8": "bq_standard:hunt"
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
     "1116:10": {
       "preRequisites:11": [
-        1115
+        1764361271
       ],
       "properties:10": {
         "betterquesting:10": {
           "desc:8": "     It seems to have dropped from §4§oXxeus§r...",
-          "frame:8": "GATE",
           "icon:10": {
             "Count:3": 1,
             "id:8": "aoa3:ultimatum_staff"
           },
-          "ismain:1": 1,
           "name:8": "Ultimatum Staff",
           "snd_complete:8": "contenttweaker:questcommon",
           "snd_update:8": "contenttweaker:questcommon",
@@ -52097,17 +54381,15 @@
     },
     "1117:10": {
       "preRequisites:11": [
-        1115
+        1764361271
       ],
       "properties:10": {
         "betterquesting:10": {
           "desc:8": "     It seems to have dropped from §4§oXxeus§r...",
-          "frame:8": "GATE",
           "icon:10": {
             "Count:3": 1,
             "id:8": "aoa3:gods_greatblade"
           },
-          "ismain:1": 1,
           "name:8": "God\u0027s Greatblade",
           "snd_complete:8": "contenttweaker:questcommon",
           "snd_update:8": "contenttweaker:questcommon",
@@ -53656,7 +55938,7 @@
       "questID:3": 1160,
       "rewards:9": {
         "0:10": {
-          "amount:3": 60,
+          "amount:3": 200,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -53845,7 +56127,7 @@
       "questID:3": 1166,
       "rewards:9": {
         "0:10": {
-          "amount:3": 80,
+          "amount:3": 300,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -56967,7 +59249,7 @@
       "questID:3": 1259,
       "rewards:9": {
         "0:10": {
-          "amount:3": 100,
+          "amount:3": 500,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -57008,7 +59290,7 @@
       "questID:3": 1260,
       "rewards:9": {
         "0:10": {
-          "amount:3": 200,
+          "amount:3": 1000,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -62555,7 +64837,7 @@
       "questID:3": 1334,
       "rewards:9": {
         "0:10": {
-          "amount:3": 100,
+          "amount:3": 1000,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -67954,13 +70236,14 @@
           },
           "name:8": "Evolved Ghast",
           "snd_complete:8": "contenttweaker:questdramatic",
-          "snd_update:8": "contenttweaker:questdramatic"
+          "snd_update:8": "contenttweaker:questdramatic",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1470,
       "rewards:9": {
         "0:10": {
-          "amount:3": 20,
+          "amount:3": 250,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         },
@@ -68097,7 +70380,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -68151,6 +70436,16 @@
             "id:8": "extraplanets:extraplanets.evolvedghastboss"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "extraplanets:t6key"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -69944,13 +72239,14 @@
           },
           "name:8": "Evolved Ice Slime",
           "snd_complete:8": "contenttweaker:questdramatic",
-          "snd_update:8": "contenttweaker:questdramatic"
+          "snd_update:8": "contenttweaker:questdramatic",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1508,
       "rewards:9": {
         "0:10": {
-          "amount:3": 20,
+          "amount:3": 500,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -70080,7 +72376,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -70136,6 +72434,16 @@
             "wasOnGround:1": 0
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "extraplanets:t7key"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -70154,13 +72462,14 @@
           },
           "name:8": "Evolved Snowman",
           "snd_complete:8": "contenttweaker:questdramatic",
-          "snd_update:8": "contenttweaker:questdramatic"
+          "snd_update:8": "contenttweaker:questdramatic",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1509,
       "rewards:9": {
         "0:10": {
-          "amount:3": 20,
+          "amount:3": 750,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         }
@@ -70290,7 +72599,9 @@
                 "tempshields:3": 0
               }
             },
-            "ForgeData:10": {},
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
             "HandDropChances:9": {
               "0:5": 0.085,
               "1:5": 0.085
@@ -70344,6 +72655,16 @@
             "id:8": "extraplanets:extraplanets.evolvedsnowmanboss"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "extraplanets:t8key"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -70363,13 +72684,14 @@
           "ismain:1": 1,
           "name:8": "Evolved Spaceman",
           "snd_complete:8": "contenttweaker:questdramatic",
-          "snd_update:8": "contenttweaker:questdramatic"
+          "snd_update:8": "contenttweaker:questdramatic",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1510,
       "rewards:9": {
         "0:10": {
-          "amount:3": 20,
+          "amount:3": 1000,
           "index:3": 0,
           "rewardID:8": "bq_standard:xp"
         },
@@ -70558,6 +72880,16 @@
             "id:8": "extraplanets:extraplanets.evolvedspacemanboss"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "extraplanets:t9key"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -71171,7 +73503,8 @@
           },
           "name:8": "Tarantula Brood Mother",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1528,
@@ -71366,6 +73699,17 @@
             "id:8": "erebus:erebus.tarantula_mini_boss"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "ignoreNBT:1": 1,
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "erebus:spider_t_shirt"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -71382,7 +73726,8 @@
           },
           "name:8": "Ghast Queen",
           "snd_complete:8": "contenttweaker:questcommon",
-          "snd_update:8": "contenttweaker:questcommon"
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1529,
@@ -71573,6 +73918,16 @@
             "id:8": "netherex:ghast_queen"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "netherex:ghast_queen_tear"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
@@ -71695,6 +74050,235 @@
     },
     "1533:10": {
       "preRequisites:11": [
+        1029,
+        783863246
+      ],
+      "properties:10": {
+        "betterquesting:10": {
+          "desc:8": "     Part of the Four §6§oFour Guardians§r.\n\nIt\u0027s projectiles will inflict Blindness.",
+          "icon:10": {
+            "Count:3": 1,
+            "id:8": "minecraft:spawn_egg",
+            "tag:10": {
+              "EntityTag:10": {
+                "id:8": "aoa3:blue_guardian"
+              }
+            }
+          },
+          "name:8": "Blue Guardian",
+          "questlogic:8": "OR",
+          "snd_complete:8": "contenttweaker:questcommon",
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
+        }
+      },
+      "questID:3": 81686143,
+      "rewards:9": {
+        "0:10": {
+          "amount:3": 90,
+          "index:3": 0,
+          "rewardID:8": "bq_standard:xp"
+        }
+      },
+      "tasks:9": {
+        "0:10": {
+          "index:3": 0,
+          "target:8": "aoa3:blue_guardian",
+          "targetNBT:10": {
+            "AABB:9": {
+              "0:6": -0.75,
+              "1:6": 0.0,
+              "2:6": -0.75,
+              "3:6": 0.75,
+              "4:6": 2.625,
+              "5:6": 0.75
+            },
+            "AbsorptionAmount:5": 0.0,
+            "Air:2": 300,
+            "ArmorDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085,
+              "2:5": 0.085,
+              "3:5": 0.085
+            },
+            "ArmorItems:9": {
+              "0:10": {},
+              "1:10": {},
+              "2:10": {},
+              "3:10": {}
+            },
+            "Attributes:9": {
+              "0:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.projectileDamage"
+              },
+              "1:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.magicDamage"
+              },
+              "2:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.jumpHeight"
+              },
+              "3:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.damageResistance"
+              },
+              "4:10": {
+                "Base:6": 0.0,
+                "Name:8": "potioncore.magicShielding"
+              },
+              "5:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.slash"
+              },
+              "6:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.pierce"
+              },
+              "7:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.impact"
+              },
+              "8:10": {
+                "Base:6": 750.0,
+                "Name:8": "generic.maxHealth"
+              },
+              "9:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.knockbackResistance"
+              },
+              "10:10": {
+                "Base:6": 0.207,
+                "Name:8": "generic.movementSpeed"
+              },
+              "11:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armor"
+              },
+              "12:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armorToughness"
+              },
+              "13:10": {
+                "Base:6": 1.0,
+                "Name:8": "forge.swimSpeed"
+              },
+              "14:10": {
+                "Base:6": 24.0,
+                "Name:8": "generic.followRange"
+              },
+              "15:10": {
+                "Base:6": 2.0,
+                "Name:8": "generic.attackDamage"
+              }
+            },
+            "CanPickUpLoot:1": 0,
+            "DeathTime:2": 0,
+            "Dimension:3": 0,
+            "FallDistance:5": 0.0,
+            "FallFlying:1": 0,
+            "Fire:2": -1,
+            "ForgeCaps:10": {
+              "aether:entityinfo:10": {
+                "hasSpawnArea:1": 0
+              },
+              "aether:statuseffects:10": {
+                "statusEffects:9": {}
+              },
+              "cavern:portal_cache:10": {
+                "LastDim:9": {},
+                "LastPos:9": {}
+              },
+              "dsurround:data:10": {
+                "a:1": 0,
+                "f:1": 0
+              },
+              "dsurround:entityfx:10": {},
+              "dsurround:speech:10": {},
+              "thebetweenlands:custom_step_sound:10": {},
+              "thebetweenlands:entity_gems:10": {
+                "gems:9": {}
+              },
+              "thebetweenlands:equipment:10": {
+                "amuletSlots:3": 1
+              },
+              "thebetweenlands:puppet:10": {
+                "guard:1": 0,
+                "recruitmentCost:3": 0,
+                "stay:1": 0,
+                "ticks:3": 0
+              },
+              "tinkertoolleveling:entityxp:9": {},
+              "twilightforest:cap_boss:10": {
+                "homePos:10": {
+                  "X:3": 0,
+                  "Y:3": 0,
+                  "Z:3": 0
+                },
+                "variant:3": -1
+              },
+              "twilightforest:cap_shield:10": {
+                "permshields:3": 0,
+                "tempshields:3": 0
+              }
+            },
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
+            "HandDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085
+            },
+            "HandItems:9": {
+              "0:10": {},
+              "1:10": {}
+            },
+            "Health:5": 750.0,
+            "HurtByTimestamp:3": 0,
+            "HurtTime:2": 0,
+            "Invulnerable:1": 0,
+            "Leashed:1": 0,
+            "LeftHanded:1": 0,
+            "Motion:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "OnGround:1": 0,
+            "PersistenceRequired:1": 0,
+            "PortalCooldown:3": 0,
+            "Pos:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "Rotation:9": {
+              "0:5": 0.44604233,
+              "1:5": 0.0
+            },
+            "UUIDLeast:4": -7331459428228310251,
+            "UUIDMost:4": -4973166960911433082,
+            "UpdateBlocked:1": 0,
+            "gravityFactor:6": 1.0,
+            "id:8": "aoa3:blue_guardian"
+          },
+          "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 4,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:guardian_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
+        }
+      }
+    },
+    "1534:10": {
+      "preRequisites:11": [
         1013197977
       ],
       "properties:10": {
@@ -71722,7 +74306,7 @@
         }
       }
     },
-    "1534:10": {
+    "1535:10": {
       "preRequisiteTypes:7": [
         2,
         0
@@ -71758,7 +74342,216 @@
         }
       }
     },
-    "1535:10": {
+    "1536:10": {
+      "preRequisites:11": [
+        1029,
+        1161281890
+      ],
+      "properties:10": {
+        "betterquesting:10": {
+          "desc:8": "     Part of the §6§oFour Guardians§r.\n\nIt shoots projectiles more often.",
+          "icon:10": {
+            "Count:3": 1,
+            "id:8": "minecraft:spawn_egg",
+            "tag:10": {
+              "EntityTag:10": {
+                "id:8": "aoa3:yellow_guardian"
+              }
+            }
+          },
+          "name:8": "Yellow Guardian",
+          "questlogic:8": "OR",
+          "snd_complete:8": "contenttweaker:questcommon",
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
+        }
+      },
+      "questID:3": 287457859,
+      "rewards:9": {
+        "0:10": {
+          "amount:3": 90,
+          "index:3": 0,
+          "rewardID:8": "bq_standard:xp"
+        }
+      },
+      "tasks:9": {
+        "0:10": {
+          "index:3": 3,
+          "target:8": "aoa3:yellow_guardian",
+          "targetNBT:10": {
+            "AbsorptionAmount:5": 0.0,
+            "Air:2": 300,
+            "ArmorDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085,
+              "2:5": 0.085,
+              "3:5": 0.085
+            },
+            "ArmorItems:9": {
+              "0:10": {},
+              "1:10": {},
+              "2:10": {},
+              "3:10": {}
+            },
+            "Attributes:9": {
+              "0:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.slash"
+              },
+              "1:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.pierce"
+              },
+              "2:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.impact"
+              },
+              "3:10": {
+                "Base:6": 750.0,
+                "Name:8": "generic.maxHealth"
+              },
+              "4:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.knockbackResistance"
+              },
+              "5:10": {
+                "Base:6": 0.207,
+                "Name:8": "generic.movementSpeed"
+              },
+              "6:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armor"
+              },
+              "7:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armorToughness"
+              },
+              "8:10": {
+                "Base:6": 1.0,
+                "Name:8": "forge.swimSpeed"
+              },
+              "9:10": {
+                "Base:6": 24.0,
+                "Name:8": "generic.followRange"
+              },
+              "10:10": {
+                "Base:6": 2.0,
+                "Name:8": "generic.attackDamage"
+              }
+            },
+            "CanPickUpLoot:1": 0,
+            "DeathTime:2": 0,
+            "Dimension:3": 0,
+            "FallDistance:5": 0.0,
+            "FallFlying:1": 0,
+            "Fire:2": -1,
+            "ForgeCaps:10": {
+              "aether:entityinfo:10": {
+                "hasSpawnArea:1": 0
+              },
+              "aether:statuseffects:10": {},
+              "cavern:portal_cache:10": {
+                "LastDim:9": {},
+                "LastPos:9": {}
+              },
+              "dsurround:data:10": {
+                "a:1": 0,
+                "f:1": 0
+              },
+              "dsurround:entityfx:10": {},
+              "dsurround:speech:10": {},
+              "enderutilities:entity_portal_cooldown:10": {
+                "LastInPortal:4": 0
+              },
+              "thebetweenlands:custom_step_sound:10": {},
+              "thebetweenlands:entity_gems:10": {
+                "gems:9": {}
+              },
+              "thebetweenlands:equipment:10": {
+                "amuletSlots:3": 1
+              },
+              "thebetweenlands:puppet:10": {
+                "guard:1": 0,
+                "recruitmentCost:3": 0,
+                "stay:1": 0,
+                "ticks:3": 0
+              },
+              "tinkertoolleveling:entityxp:9": {},
+              "twilightforest:cap_shield:10": {
+                "permshields:3": 0,
+                "tempshields:3": 0
+              }
+            },
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
+            "HandDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085
+            },
+            "HandItems:9": {
+              "0:10": {},
+              "1:10": {}
+            },
+            "Health:5": 750.0,
+            "HurtByTimestamp:3": 0,
+            "HurtTime:2": 0,
+            "Invulnerable:1": 0,
+            "Leashed:1": 0,
+            "LeftHanded:1": 0,
+            "Motion:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "OnGround:1": 0,
+            "PersistenceRequired:1": 0,
+            "PortalCooldown:3": 0,
+            "Pos:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "RelativeAABB:9": {
+              "0:6": -0.30000001192092896,
+              "1:6": 0.0,
+              "2:6": -0.30000001192092896,
+              "3:6": 1.199999988079071,
+              "4:6": 2.625,
+              "5:6": 1.199999988079071
+            },
+            "Rotation:9": {
+              "0:5": 3.4817476,
+              "1:5": 0.0
+            },
+            "SurgeAABB:9": {
+              "0:6": -0.30000001192092896,
+              "1:6": 0.0,
+              "2:6": -0.30000001192092896,
+              "3:6": 1.199999988079071,
+              "4:6": 2.625,
+              "5:6": 1.199999988079071
+            },
+            "UUIDLeast:4": -5331761567068515474,
+            "UUIDMost:4": -248987504982799417,
+            "UpdateBlocked:1": 0,
+            "id:8": "aoa3:yellow_guardian"
+          },
+          "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 4,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:guardian_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
+        }
+      }
+    },
+    "1537:10": {
       "preRequisites:11": [
         1428433352
       ],
@@ -71769,7 +74562,8 @@
             "Count:3": 1,
             "id:8": "theaurorian:trophymoonqueen"
           },
-          "name:8": "Moon Queen"
+          "name:8": "Moon Queen",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 297079895,
@@ -71980,10 +74774,683 @@
             "id:8": "theaurorian:moonqueen"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "theaurorian:trophymoonqueen"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
-    "1536:10": {
+    "1538:10": {
+      "properties:10": {
+        "betterquesting:10": {
+          "desc:8": "No Description",
+          "icon:10": {
+            "Count:3": 1,
+            "id:8": "minecraft:nether_star"
+          },
+          "name:8": "New Quest"
+        }
+      },
+      "questID:3": 412032718,
+      "tasks:9": {}
+    },
+    "1539:10": {
+      "preRequisites:11": [
+        1086,
+        1796449058
+      ],
+      "properties:10": {
+        "betterquesting:10": {
+          "desc:8": "     The third of the §8§oPrimordial Five§r. Passively regenerates health and may randomly jump into the air.",
+          "icon:10": {
+            "Count:3": 1,
+            "id:8": "aoa3:ornate_harkos_statue"
+          },
+          "name:8": "Harkos",
+          "questlogic:8": "OR",
+          "snd_complete:8": "contenttweaker:questcommon",
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
+        }
+      },
+      "questID:3": 475586045,
+      "rewards:9": {
+        "0:10": {
+          "amount:3": 85,
+          "index:3": 0,
+          "rewardID:8": "bq_standard:xp"
+        }
+      },
+      "tasks:9": {
+        "0:10": {
+          "index:3": 0,
+          "target:8": "aoa3:harkos",
+          "targetNBT:10": {
+            "AABB:9": {
+              "0:6": -0.3499999940395355,
+              "1:6": 0.0,
+              "2:6": -0.3499999940395355,
+              "3:6": 0.3499999940395355,
+              "4:6": 2.375,
+              "5:6": 0.3499999940395355
+            },
+            "AbsorptionAmount:5": 0.0,
+            "Air:2": 300,
+            "ArmorDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085,
+              "2:5": 0.085,
+              "3:5": 0.085
+            },
+            "ArmorItems:9": {
+              "0:10": {},
+              "1:10": {},
+              "2:10": {},
+              "3:10": {}
+            },
+            "Attributes:9": {
+              "0:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.projectileDamage"
+              },
+              "1:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.magicDamage"
+              },
+              "2:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.jumpHeight"
+              },
+              "3:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.damageResistance"
+              },
+              "4:10": {
+                "Base:6": 0.0,
+                "Name:8": "potioncore.magicShielding"
+              },
+              "5:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.slash"
+              },
+              "6:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.pierce"
+              },
+              "7:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.impact"
+              },
+              "8:10": {
+                "Base:6": 1300.0,
+                "Name:8": "generic.maxHealth"
+              },
+              "9:10": {
+                "Base:6": 0.3,
+                "Name:8": "generic.knockbackResistance"
+              },
+              "10:10": {
+                "Base:6": 0.329,
+                "Name:8": "generic.movementSpeed"
+              },
+              "11:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armor"
+              },
+              "12:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armorToughness"
+              },
+              "13:10": {
+                "Base:6": 1.0,
+                "Name:8": "forge.swimSpeed"
+              },
+              "14:10": {
+                "Base:6": 16.0,
+                "Name:8": "generic.followRange"
+              },
+              "15:10": {
+                "Base:6": 13.0,
+                "Name:8": "generic.attackDamage"
+              }
+            },
+            "CanPickUpLoot:1": 0,
+            "DeathTime:2": 0,
+            "Dimension:3": 428,
+            "FallDistance:5": 0.0,
+            "FallFlying:1": 0,
+            "Fire:2": -1,
+            "ForgeCaps:10": {
+              "aether:entityinfo:10": {
+                "hasSpawnArea:1": 0
+              },
+              "aether:statuseffects:10": {
+                "statusEffects:9": {}
+              },
+              "cavern:portal_cache:10": {
+                "LastDim:9": {},
+                "LastPos:9": {}
+              },
+              "dsurround:data:10": {
+                "a:1": 0,
+                "f:1": 0
+              },
+              "dsurround:entityfx:10": {},
+              "dsurround:speech:10": {},
+              "thebetweenlands:custom_step_sound:10": {},
+              "thebetweenlands:entity_gems:10": {
+                "gems:9": {}
+              },
+              "thebetweenlands:equipment:10": {
+                "amuletSlots:3": 1
+              },
+              "thebetweenlands:puppet:10": {
+                "guard:1": 0,
+                "recruitmentCost:3": 0,
+                "stay:1": 0,
+                "ticks:3": 0
+              },
+              "tinkertoolleveling:entityxp:9": {},
+              "twilightforest:cap_boss:10": {
+                "homePos:10": {
+                  "X:3": 0,
+                  "Y:3": 0,
+                  "Z:3": 0
+                },
+                "variant:3": -1
+              },
+              "twilightforest:cap_shield:10": {
+                "permshields:3": 0,
+                "tempshields:3": 0
+              }
+            },
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
+            "HandDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085
+            },
+            "HandItems:9": {
+              "0:10": {},
+              "1:10": {}
+            },
+            "Health:5": 1300.0,
+            "HurtByTimestamp:3": 0,
+            "HurtTime:2": 0,
+            "Invulnerable:1": 0,
+            "Leashed:1": 0,
+            "LeftHanded:1": 0,
+            "Motion:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "OnGround:1": 0,
+            "PersistenceRequired:1": 0,
+            "PortalCooldown:3": 0,
+            "Pos:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "Rotation:9": {
+              "0:5": 6.20506,
+              "1:5": 0.0
+            },
+            "UUIDLeast:4": -5287025095863278833,
+            "UUIDMost:4": -4111253204265516858,
+            "UpdateBlocked:1": 0,
+            "gravityFactor:6": 1.0,
+            "id:8": "aoa3:harkos"
+          },
+          "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:harkos_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
+        }
+      }
+    },
+    "1540:10": {
+      "preRequisites:11": [
+        1086,
+        475586045
+      ],
+      "properties:10": {
+        "betterquesting:10": {
+          "desc:8": "     The fourth of the §8§oPrimordial Five§r. Can turn invisible and affect you with Nausea.",
+          "icon:10": {
+            "Count:3": 1,
+            "id:8": "aoa3:ornate_raxxan_statue"
+          },
+          "name:8": "Raxxan",
+          "questlogic:8": "OR",
+          "snd_complete:8": "contenttweaker:questcommon",
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
+        }
+      },
+      "questID:3": 482665851,
+      "rewards:9": {
+        "0:10": {
+          "amount:3": 85,
+          "index:3": 0,
+          "rewardID:8": "bq_standard:xp"
+        }
+      },
+      "tasks:9": {
+        "0:10": {
+          "index:3": 3,
+          "target:8": "aoa3:raxxan",
+          "targetNBT:10": {
+            "AbsorptionAmount:5": 0.0,
+            "Air:2": 300,
+            "ArmorDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085,
+              "2:5": 0.085,
+              "3:5": 0.085
+            },
+            "ArmorItems:9": {
+              "0:10": {},
+              "1:10": {},
+              "2:10": {},
+              "3:10": {}
+            },
+            "Attributes:9": {
+              "0:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.slash"
+              },
+              "1:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.pierce"
+              },
+              "2:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.impact"
+              },
+              "3:10": {
+                "Base:6": 1000.0,
+                "Name:8": "generic.maxHealth"
+              },
+              "4:10": {
+                "Base:6": 1.0,
+                "Name:8": "generic.knockbackResistance"
+              },
+              "5:10": {
+                "Base:6": 0.329,
+                "Name:8": "generic.movementSpeed"
+              },
+              "6:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armor"
+              },
+              "7:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armorToughness"
+              },
+              "8:10": {
+                "Base:6": 1.0,
+                "Name:8": "forge.swimSpeed"
+              },
+              "9:10": {
+                "Base:6": 16.0,
+                "Name:8": "generic.followRange"
+              },
+              "10:10": {
+                "Base:6": 15.0,
+                "Name:8": "generic.attackDamage"
+              }
+            },
+            "CanPickUpLoot:1": 0,
+            "DeathTime:2": 0,
+            "Dimension:3": 0,
+            "FallDistance:5": 0.0,
+            "FallFlying:1": 0,
+            "Fire:2": -1,
+            "ForgeCaps:10": {
+              "aether:entityinfo:10": {
+                "hasSpawnArea:1": 0
+              },
+              "aether:statuseffects:10": {},
+              "cavern:portal_cache:10": {
+                "LastDim:9": {},
+                "LastPos:9": {}
+              },
+              "dsurround:data:10": {
+                "a:1": 0,
+                "f:1": 0
+              },
+              "dsurround:entityfx:10": {},
+              "dsurround:speech:10": {},
+              "enderutilities:entity_portal_cooldown:10": {
+                "LastInPortal:4": 0
+              },
+              "thebetweenlands:custom_step_sound:10": {},
+              "thebetweenlands:entity_gems:10": {
+                "gems:9": {}
+              },
+              "thebetweenlands:equipment:10": {
+                "amuletSlots:3": 1
+              },
+              "thebetweenlands:puppet:10": {
+                "guard:1": 0,
+                "recruitmentCost:3": 0,
+                "stay:1": 0,
+                "ticks:3": 0
+              },
+              "tinkertoolleveling:entityxp:9": {},
+              "twilightforest:cap_shield:10": {
+                "permshields:3": 0,
+                "tempshields:3": 0
+              }
+            },
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
+            "HandDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085
+            },
+            "HandItems:9": {
+              "0:10": {},
+              "1:10": {}
+            },
+            "Health:5": 1000.0,
+            "HurtByTimestamp:3": 0,
+            "HurtTime:2": 0,
+            "Invulnerable:1": 0,
+            "Leashed:1": 0,
+            "LeftHanded:1": 0,
+            "Motion:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "OnGround:1": 0,
+            "PersistenceRequired:1": 0,
+            "PortalCooldown:3": 0,
+            "Pos:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "RelativeAABB:9": {
+              "0:6": -0.30000001192092896,
+              "1:6": 0.0,
+              "2:6": -0.30000001192092896,
+              "3:6": 0.3999999761581421,
+              "4:6": 2.375,
+              "5:6": 0.3999999761581421
+            },
+            "Rotation:9": {
+              "0:5": 0.20942791,
+              "1:5": 0.0
+            },
+            "SurgeAABB:9": {
+              "0:6": -0.30000001192092896,
+              "1:6": 0.0,
+              "2:6": -0.30000001192092896,
+              "3:6": 0.3999999761581421,
+              "4:6": 2.375,
+              "5:6": 0.3999999761581421
+            },
+            "UUIDLeast:4": -7746234037096303460,
+            "UUIDMost:4": -272861703312422020,
+            "UpdateBlocked:1": 0,
+            "id:8": "aoa3:raxxan"
+          },
+          "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 5,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:raxxan_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
+        }
+      }
+    },
+    "1541:10": {
+      "preRequisites:11": [
+        1086
+      ],
+      "properties:10": {
+        "betterquesting:10": {
+          "desc:8": "     The First of the §8§oPrimordial Five§r. They can be summoned by lighting all §5§oDustopian Lamps§r in the primordial shrine found within the realm of §d§oDustopia§r.",
+          "icon:10": {
+            "Count:3": 1,
+            "id:8": "aoa3:ornate_kajaros_statue"
+          },
+          "name:8": "Kajaros",
+          "snd_complete:8": "contenttweaker:questcommon",
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
+        }
+      },
+      "questID:3": 567514731,
+      "rewards:9": {
+        "0:10": {
+          "amount:3": 85,
+          "index:3": 0,
+          "rewardID:8": "bq_standard:xp"
+        }
+      },
+      "tasks:9": {
+        "0:10": {
+          "index:3": 0,
+          "target:8": "aoa3:kajaros",
+          "targetNBT:10": {
+            "AbsorptionAmount:5": 0.0,
+            "Air:2": 300,
+            "ArmorDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085,
+              "2:5": 0.085,
+              "3:5": 0.085
+            },
+            "ArmorItems:9": {
+              "0:10": {},
+              "1:10": {},
+              "2:10": {},
+              "3:10": {}
+            },
+            "Attributes:9": {
+              "0:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.slash"
+              },
+              "1:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.pierce"
+              },
+              "2:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.impact"
+              },
+              "3:10": {
+                "Base:6": 1750.0,
+                "Name:8": "generic.maxHealth"
+              },
+              "4:10": {
+                "Base:6": 0.8,
+                "Name:8": "generic.knockbackResistance"
+              },
+              "5:10": {
+                "Base:6": 0.2875,
+                "Name:8": "generic.movementSpeed"
+              },
+              "6:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armor"
+              },
+              "7:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armorToughness"
+              },
+              "8:10": {
+                "Base:6": 1.0,
+                "Name:8": "forge.swimSpeed"
+              },
+              "9:10": {
+                "Base:6": 16.0,
+                "Name:8": "generic.followRange"
+              },
+              "10:10": {
+                "Base:6": 23.0,
+                "Name:8": "generic.attackDamage"
+              }
+            },
+            "CanPickUpLoot:1": 0,
+            "DeathTime:2": 0,
+            "Dimension:3": 0,
+            "FallDistance:5": 0.0,
+            "FallFlying:1": 0,
+            "Fire:2": -1,
+            "ForgeCaps:10": {
+              "aether:entityinfo:10": {
+                "hasSpawnArea:1": 0
+              },
+              "aether:statuseffects:10": {},
+              "cavern:portal_cache:10": {
+                "LastDim:9": {},
+                "LastPos:9": {}
+              },
+              "dsurround:data:10": {
+                "a:1": 0,
+                "f:1": 0
+              },
+              "dsurround:entityfx:10": {},
+              "dsurround:speech:10": {},
+              "enderutilities:entity_portal_cooldown:10": {
+                "LastInPortal:4": 0
+              },
+              "thebetweenlands:custom_step_sound:10": {},
+              "thebetweenlands:entity_gems:10": {
+                "gems:9": {}
+              },
+              "thebetweenlands:equipment:10": {
+                "amuletSlots:3": 1
+              },
+              "thebetweenlands:puppet:10": {
+                "guard:1": 0,
+                "recruitmentCost:3": 0,
+                "stay:1": 0,
+                "ticks:3": 0
+              },
+              "tinkertoolleveling:entityxp:9": {},
+              "twilightforest:cap_shield:10": {
+                "permshields:3": 0,
+                "tempshields:3": 0
+              }
+            },
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
+            "HandDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085
+            },
+            "HandItems:9": {
+              "0:10": {},
+              "1:10": {}
+            },
+            "Health:5": 1750.0,
+            "HurtByTimestamp:3": 0,
+            "HurtTime:2": 0,
+            "Invulnerable:1": 0,
+            "Leashed:1": 0,
+            "LeftHanded:1": 0,
+            "Motion:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "OnGround:1": 0,
+            "PersistenceRequired:1": 0,
+            "PortalCooldown:3": 0,
+            "Pos:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "RelativeAABB:9": {
+              "0:6": -0.30000001192092896,
+              "1:6": 0.0,
+              "2:6": -0.30000001192092896,
+              "3:6": 0.3999999761581421,
+              "4:6": 2.375,
+              "5:6": 0.3999999761581421
+            },
+            "Rotation:9": {
+              "0:5": 1.9525961,
+              "1:5": 0.0
+            },
+            "SurgeAABB:9": {
+              "0:6": -0.30000001192092896,
+              "1:6": 0.0,
+              "2:6": -0.30000001192092896,
+              "3:6": 0.3999999761581421,
+              "4:6": 2.375,
+              "5:6": 0.3999999761581421
+            },
+            "UUIDLeast:4": -8421033474184529171,
+            "UUIDMost:4": 690841793034339129,
+            "UpdateBlocked:1": 0,
+            "id:8": "aoa3:kajaros"
+          },
+          "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:kajaros_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
+        }
+      }
+    },
+    "1542:10": {
+      "properties:10": {
+        "betterquesting:10": {
+          "desc:8": "No Description",
+          "icon:10": {
+            "Count:3": 1,
+            "id:8": "minecraft:spawn_egg",
+            "tag:10": {
+              "EntityTag:10": {
+                "id:8": "aoa3:green_guardian"
+              }
+            }
+          },
+          "name:8": "New Quest"
+        }
+      },
+      "questID:3": 627231381,
+      "tasks:9": {}
+    },
+    "1543:10": {
       "preRequisites:11": [
         234,
         52,
@@ -72013,7 +75480,244 @@
         }
       }
     },
-    "1537:10": {
+    "1544:10": {
+      "preRequisites:11": [
+        1029,
+        287457859
+      ],
+      "properties:10": {
+        "betterquesting:10": {
+          "desc:8": "     Part of the §6§oFour Guardians§r.\n\nIts projectiles explode on impact.",
+          "icon:10": {
+            "Count:3": 1,
+            "id:8": "minecraft:spawn_egg",
+            "tag:10": {
+              "EntityTag:10": {
+                "id:8": "aoa3:green_guardian"
+              }
+            }
+          },
+          "name:8": "Green Guardian",
+          "questlogic:8": "OR",
+          "snd_complete:8": "contenttweaker:questcommon",
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
+        }
+      },
+      "questID:3": 783863246,
+      "rewards:9": {
+        "0:10": {
+          "amount:3": 90,
+          "index:3": 0,
+          "rewardID:8": "bq_standard:xp"
+        }
+      },
+      "tasks:9": {
+        "0:10": {
+          "index:3": 1,
+          "target:8": "aoa3:green_guardian",
+          "targetNBT:10": {
+            "AbsorptionAmount:5": 0.0,
+            "Air:2": 300,
+            "ArmorDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085,
+              "2:5": 0.085,
+              "3:5": 0.085
+            },
+            "ArmorItems:9": {
+              "0:10": {},
+              "1:10": {},
+              "2:10": {},
+              "3:10": {}
+            },
+            "Attributes:9": {
+              "0:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.slash"
+              },
+              "1:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.pierce"
+              },
+              "2:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.impact"
+              },
+              "3:10": {
+                "Base:6": 750.0,
+                "Name:8": "generic.maxHealth"
+              },
+              "4:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.knockbackResistance"
+              },
+              "5:10": {
+                "Base:6": 0.207,
+                "Name:8": "generic.movementSpeed"
+              },
+              "6:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armor"
+              },
+              "7:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armorToughness"
+              },
+              "8:10": {
+                "Base:6": 1.0,
+                "Name:8": "forge.swimSpeed"
+              },
+              "9:10": {
+                "Base:6": 24.0,
+                "Name:8": "generic.followRange"
+              },
+              "10:10": {
+                "Base:6": 2.0,
+                "Name:8": "generic.attackDamage"
+              }
+            },
+            "CanPickUpLoot:1": 0,
+            "DeathTime:2": 0,
+            "Dimension:3": 0,
+            "FallDistance:5": 0.0,
+            "FallFlying:1": 0,
+            "Fire:2": -1,
+            "ForgeCaps:10": {
+              "aether:entityinfo:10": {
+                "hasSpawnArea:1": 0
+              },
+              "aether:statuseffects:10": {},
+              "cavern:portal_cache:10": {
+                "LastDim:9": {},
+                "LastPos:9": {}
+              },
+              "dsurround:data:10": {
+                "a:1": 0,
+                "f:1": 0
+              },
+              "dsurround:entityfx:10": {},
+              "dsurround:speech:10": {},
+              "enderutilities:entity_portal_cooldown:10": {
+                "LastInPortal:4": 0
+              },
+              "thebetweenlands:custom_step_sound:10": {},
+              "thebetweenlands:entity_gems:10": {
+                "gems:9": {}
+              },
+              "thebetweenlands:equipment:10": {
+                "amuletSlots:3": 1
+              },
+              "thebetweenlands:puppet:10": {
+                "guard:1": 0,
+                "recruitmentCost:3": 0,
+                "stay:1": 0,
+                "ticks:3": 0
+              },
+              "tinkertoolleveling:entityxp:9": {},
+              "twilightforest:cap_shield:10": {
+                "permshields:3": 0,
+                "tempshields:3": 0
+              }
+            },
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
+            "HandDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085
+            },
+            "HandItems:9": {
+              "0:10": {},
+              "1:10": {}
+            },
+            "Health:5": 750.0,
+            "HurtByTimestamp:3": 0,
+            "HurtTime:2": 0,
+            "Invulnerable:1": 0,
+            "Leashed:1": 0,
+            "LeftHanded:1": 0,
+            "Motion:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "OnGround:1": 0,
+            "PersistenceRequired:1": 0,
+            "PortalCooldown:3": 0,
+            "Pos:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "RelativeAABB:9": {
+              "0:6": -0.30000001192092896,
+              "1:6": 0.0,
+              "2:6": -0.30000001192092896,
+              "3:6": 1.199999988079071,
+              "4:6": 2.625,
+              "5:6": 1.199999988079071
+            },
+            "Rotation:9": {
+              "0:5": 0.42690685,
+              "1:5": 0.0
+            },
+            "SurgeAABB:9": {
+              "0:6": -0.30000001192092896,
+              "1:6": 0.0,
+              "2:6": -0.30000001192092896,
+              "3:6": 1.199999988079071,
+              "4:6": 2.625,
+              "5:6": 1.199999988079071
+            },
+            "UUIDLeast:4": -8199203411366966218,
+            "UUIDMost:4": 8529556988127300111,
+            "UpdateBlocked:1": 0,
+            "id:8": "aoa3:green_guardian"
+          },
+          "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 4,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:guardian_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
+        }
+      }
+    },
+    "1545:10": {
+      "properties:10": {
+        "betterquesting:10": {
+          "desc:8": "No Description",
+          "icon:10": {
+            "Count:3": 1,
+            "id:8": "minecraft:nether_star"
+          },
+          "name:8": "New Quest"
+        }
+      },
+      "questID:3": 926959874,
+      "tasks:9": {}
+    },
+    "1546:10": {
+      "properties:10": {
+        "betterquesting:10": {
+          "desc:8": "No Description",
+          "icon:10": {
+            "Count:3": 1,
+            "id:8": "minecraft:nether_star"
+          },
+          "name:8": "New Quest"
+        }
+      },
+      "questID:3": 954386930,
+      "tasks:9": {}
+    },
+    "1547:10": {
       "preRequisiteTypes:7": [
         2
       ],
@@ -72045,14 +75749,14 @@
         }
       }
     },
-    "1538:10": {
+    "1548:10": {
       "preRequisiteTypes:7": [
         2,
         0
       ],
       "preRequisites:11": [
         60,
-        258
+        238
       ],
       "properties:10": {
         "betterquesting:10": {
@@ -72080,7 +75784,223 @@
         }
       }
     },
-    "1539:10": {
+    "1549:10": {
+      "properties:10": {
+        "betterquesting:10": {
+          "desc:8": "No Description",
+          "icon:10": {
+            "Count:3": 1,
+            "id:8": "minecraft:nether_star"
+          },
+          "name:8": "New Quest"
+        }
+      },
+      "questID:3": 1049046996,
+      "tasks:9": {}
+    },
+    "1550:10": {
+      "preRequisites:11": [
+        1029
+      ],
+      "properties:10": {
+        "betterquesting:10": {
+          "desc:8": "     Part of the §6§oFour Guardians§r, which can be summoned by using a§5 §oVoliant Heart§r on a §d§oGuardian Altar§r after the levers have been connected via redstone. Their drops depend on which one you kill last.\n\nIt\u0027s projectiles inflict Slowness.",
+          "icon:10": {
+            "Count:3": 1,
+            "id:8": "aoa3:ornate_guardian_statue"
+          },
+          "name:8": "Red Guardian",
+          "snd_complete:8": "contenttweaker:questcommon",
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
+        }
+      },
+      "questID:3": 1161281890,
+      "rewards:9": {
+        "0:10": {
+          "amount:3": 90,
+          "index:3": 0,
+          "rewardID:8": "bq_standard:xp"
+        }
+      },
+      "tasks:9": {
+        "0:10": {
+          "index:3": 2,
+          "target:8": "aoa3:red_guardian",
+          "targetNBT:10": {
+            "AbsorptionAmount:5": 0.0,
+            "Air:2": 300,
+            "ArmorDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085,
+              "2:5": 0.085,
+              "3:5": 0.085
+            },
+            "ArmorItems:9": {
+              "0:10": {},
+              "1:10": {},
+              "2:10": {},
+              "3:10": {}
+            },
+            "Attributes:9": {
+              "0:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.slash"
+              },
+              "1:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.pierce"
+              },
+              "2:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.impact"
+              },
+              "3:10": {
+                "Base:6": 750.0,
+                "Name:8": "generic.maxHealth"
+              },
+              "4:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.knockbackResistance"
+              },
+              "5:10": {
+                "Base:6": 0.207,
+                "Name:8": "generic.movementSpeed"
+              },
+              "6:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armor"
+              },
+              "7:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armorToughness"
+              },
+              "8:10": {
+                "Base:6": 1.0,
+                "Name:8": "forge.swimSpeed"
+              },
+              "9:10": {
+                "Base:6": 24.0,
+                "Name:8": "generic.followRange"
+              },
+              "10:10": {
+                "Base:6": 2.0,
+                "Name:8": "generic.attackDamage"
+              }
+            },
+            "CanPickUpLoot:1": 0,
+            "DeathTime:2": 0,
+            "Dimension:3": 0,
+            "FallDistance:5": 0.0,
+            "FallFlying:1": 0,
+            "Fire:2": -1,
+            "ForgeCaps:10": {
+              "aether:entityinfo:10": {
+                "hasSpawnArea:1": 0
+              },
+              "aether:statuseffects:10": {},
+              "cavern:portal_cache:10": {
+                "LastDim:9": {},
+                "LastPos:9": {}
+              },
+              "dsurround:data:10": {
+                "a:1": 0,
+                "f:1": 0
+              },
+              "dsurround:entityfx:10": {},
+              "dsurround:speech:10": {},
+              "enderutilities:entity_portal_cooldown:10": {
+                "LastInPortal:4": 0
+              },
+              "thebetweenlands:custom_step_sound:10": {},
+              "thebetweenlands:entity_gems:10": {
+                "gems:9": {}
+              },
+              "thebetweenlands:equipment:10": {
+                "amuletSlots:3": 1
+              },
+              "thebetweenlands:puppet:10": {
+                "guard:1": 0,
+                "recruitmentCost:3": 0,
+                "stay:1": 0,
+                "ticks:3": 0
+              },
+              "tinkertoolleveling:entityxp:9": {},
+              "twilightforest:cap_shield:10": {
+                "permshields:3": 0,
+                "tempshields:3": 0
+              }
+            },
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
+            "HandDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085
+            },
+            "HandItems:9": {
+              "0:10": {},
+              "1:10": {}
+            },
+            "Health:5": 750.0,
+            "HurtByTimestamp:3": 0,
+            "HurtTime:2": 0,
+            "Invulnerable:1": 0,
+            "Leashed:1": 0,
+            "LeftHanded:1": 0,
+            "Motion:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "OnGround:1": 0,
+            "PersistenceRequired:1": 0,
+            "PortalCooldown:3": 0,
+            "Pos:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "RelativeAABB:9": {
+              "0:6": -0.30000001192092896,
+              "1:6": 0.0,
+              "2:6": -0.30000001192092896,
+              "3:6": 1.199999988079071,
+              "4:6": 2.625,
+              "5:6": 1.199999988079071
+            },
+            "Rotation:9": {
+              "0:5": 0.6291518,
+              "1:5": 0.0
+            },
+            "SurgeAABB:9": {
+              "0:6": -0.30000001192092896,
+              "1:6": 0.0,
+              "2:6": -0.30000001192092896,
+              "3:6": 1.199999988079071,
+              "4:6": 2.625,
+              "5:6": 1.199999988079071
+            },
+            "UUIDLeast:4": -6637748681003651435,
+            "UUIDMost:4": -806264916546466013,
+            "UpdateBlocked:1": 0,
+            "id:8": "aoa3:red_guardian"
+          },
+          "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 4,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:guardian_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
+        }
+      }
+    },
+    "1551:10": {
       "preRequisites:11": [
         240
       ],
@@ -72110,7 +76030,230 @@
         }
       }
     },
-    "1540:10": {
+    "1552:10": {
+      "preRequisites:11": [
+        1086,
+        482665851
+      ],
+      "properties:10": {
+        "betterquesting:10": {
+          "desc:8": "     The last of the §8§oPrimordial Five§r. Will fully heal after hitting you enough times.",
+          "icon:10": {
+            "Count:3": 1,
+            "id:8": "aoa3:ornate_okazor_statue"
+          },
+          "name:8": "Okazor",
+          "questlogic:8": "OR",
+          "snd_complete:8": "contenttweaker:questcommon",
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
+        }
+      },
+      "questID:3": 1260129780,
+      "rewards:9": {
+        "0:10": {
+          "amount:3": 85,
+          "index:3": 0,
+          "rewardID:8": "bq_standard:xp"
+        }
+      },
+      "tasks:9": {
+        "0:10": {
+          "index:3": 4,
+          "target:8": "aoa3:okazor",
+          "targetNBT:10": {
+            "AbsorptionAmount:5": 0.0,
+            "Air:2": 300,
+            "ArmorDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085,
+              "2:5": 0.085,
+              "3:5": 0.085
+            },
+            "ArmorItems:9": {
+              "0:10": {},
+              "1:10": {},
+              "2:10": {},
+              "3:10": {}
+            },
+            "Attributes:9": {
+              "0:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.slash"
+              },
+              "1:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.pierce"
+              },
+              "2:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.impact"
+              },
+              "3:10": {
+                "Base:6": 1200.0,
+                "Name:8": "generic.maxHealth"
+              },
+              "4:10": {
+                "Base:6": 0.8,
+                "Name:8": "generic.knockbackResistance"
+              },
+              "5:10": {
+                "Base:6": 0.2875,
+                "Name:8": "generic.movementSpeed"
+              },
+              "6:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armor"
+              },
+              "7:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armorToughness"
+              },
+              "8:10": {
+                "Base:6": 1.0,
+                "Name:8": "forge.swimSpeed"
+              },
+              "9:10": {
+                "Base:6": 16.0,
+                "Name:8": "generic.followRange"
+              },
+              "10:10": {
+                "Base:6": 50.0,
+                "Name:8": "generic.attackDamage"
+              }
+            },
+            "CanPickUpLoot:1": 0,
+            "DeathTime:2": 0,
+            "Dimension:3": 0,
+            "FallDistance:5": 0.0,
+            "FallFlying:1": 0,
+            "Fire:2": -1,
+            "ForgeCaps:10": {
+              "aether:entityinfo:10": {
+                "hasSpawnArea:1": 0
+              },
+              "aether:statuseffects:10": {},
+              "cavern:portal_cache:10": {
+                "LastDim:9": {},
+                "LastPos:9": {}
+              },
+              "dsurround:data:10": {
+                "a:1": 0,
+                "f:1": 0
+              },
+              "dsurround:entityfx:10": {},
+              "dsurround:speech:10": {},
+              "enderutilities:entity_portal_cooldown:10": {
+                "LastInPortal:4": 0
+              },
+              "thebetweenlands:custom_step_sound:10": {},
+              "thebetweenlands:entity_gems:10": {
+                "gems:9": {}
+              },
+              "thebetweenlands:equipment:10": {
+                "amuletSlots:3": 1
+              },
+              "thebetweenlands:puppet:10": {
+                "guard:1": 0,
+                "recruitmentCost:3": 0,
+                "stay:1": 0,
+                "ticks:3": 0
+              },
+              "tinkertoolleveling:entityxp:9": {},
+              "twilightforest:cap_shield:10": {
+                "permshields:3": 0,
+                "tempshields:3": 0
+              }
+            },
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
+            "HandDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085
+            },
+            "HandItems:9": {
+              "0:10": {},
+              "1:10": {}
+            },
+            "Health:5": 1200.0,
+            "HurtByTimestamp:3": 0,
+            "HurtTime:2": 0,
+            "Invulnerable:1": 0,
+            "Leashed:1": 0,
+            "LeftHanded:1": 0,
+            "Motion:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "OnGround:1": 0,
+            "PersistenceRequired:1": 0,
+            "PortalCooldown:3": 0,
+            "Pos:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "RelativeAABB:9": {
+              "0:6": -0.30000001192092896,
+              "1:6": 0.0,
+              "2:6": -0.30000001192092896,
+              "3:6": 0.3999999761581421,
+              "4:6": 2.375,
+              "5:6": 0.3999999761581421
+            },
+            "Rotation:9": {
+              "0:5": 5.2286553,
+              "1:5": 0.0
+            },
+            "SurgeAABB:9": {
+              "0:6": -0.30000001192092896,
+              "1:6": 0.0,
+              "2:6": -0.30000001192092896,
+              "3:6": 0.3999999761581421,
+              "4:6": 2.375,
+              "5:6": 0.3999999761581421
+            },
+            "UUIDLeast:4": -7456107527187910585,
+            "UUIDMost:4": -4182285288753314152,
+            "UpdateBlocked:1": 0,
+            "id:8": "aoa3:okazor"
+          },
+          "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 5,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:okazor_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
+        }
+      }
+    },
+    "1553:10": {
+      "properties:10": {
+        "betterquesting:10": {
+          "desc:8": "No Description",
+          "icon:10": {
+            "Count:3": 1,
+            "id:8": "minecraft:spawn_egg",
+            "tag:10": {
+              "EntityTag:10": {
+                "id:8": "aoa3:yellow_guardian"
+              }
+            }
+          },
+          "name:8": "New Quest"
+        }
+      },
+      "questID:3": 1265871405,
+      "tasks:9": {}
+    },
+    "1554:10": {
       "preRequisiteTypes:7": [
         0,
         2,
@@ -72146,7 +76289,7 @@
         }
       }
     },
-    "1541:10": {
+    "1555:10": {
       "preRequisites:11": [
         314
       ],
@@ -72186,7 +76329,26 @@
         }
       }
     },
-    "1542:10": {
+    "1556:10": {
+      "properties:10": {
+        "betterquesting:10": {
+          "desc:8": "No Description",
+          "icon:10": {
+            "Count:3": 1,
+            "id:8": "minecraft:spawn_egg",
+            "tag:10": {
+              "EntityTag:10": {
+                "id:8": "aoa3:blue_guardian"
+              }
+            }
+          },
+          "name:8": "New Quest"
+        }
+      },
+      "questID:3": 1359702783,
+      "tasks:9": {}
+    },
+    "1557:10": {
       "preRequisites:11": [
         273
       ],
@@ -72197,7 +76359,8 @@
             "Count:3": 1,
             "id:8": "theaurorian:trophyspider"
           },
-          "name:8": "Spider Mother"
+          "name:8": "Spider Mother",
+          "tasklogic:8": "OR"
         }
       },
       "questID:3": 1428433352,
@@ -72392,10 +76555,23 @@
             "id:8": "theaurorian:spider"
           },
           "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "theaurorian:trophyspider"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
         }
       }
     },
-    "1543:10": {
+    "1558:10": {
+      "preRequisiteTypes:7": [
+        2
+      ],
       "preRequisites:11": [
         238
       ],
@@ -72424,7 +76600,7 @@
         }
       }
     },
-    "1544:10": {
+    "1559:10": {
       "preRequisites:11": [
         1499,
         1495
@@ -72551,6 +76727,448 @@
           "taskID:8": "bq_standard:optional_retrieval"
         }
       }
+    },
+    "1560:10": {
+      "preRequisites:11": [
+        1114,
+        1115
+      ],
+      "properties:10": {
+        "betterquesting:10": {
+          "desc:8": "     Second Phase of §e§oCraexxues§r. May leap towards you.",
+          "icon:10": {
+            "Count:3": 1,
+            "id:8": "aoa3:ornate_xxeus_statue"
+          },
+          "name:8": "Xxeus",
+          "questlogic:8": "OR",
+          "snd_complete:8": "contenttweaker:questcommon",
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
+        }
+      },
+      "questID:3": 1764361271,
+      "rewards:9": {
+        "0:10": {
+          "amount:3": 95,
+          "index:3": 0,
+          "rewardID:8": "bq_standard:xp"
+        }
+      },
+      "tasks:9": {
+        "0:10": {
+          "index:3": 1,
+          "target:8": "aoa3:xxeus",
+          "targetNBT:10": {
+            "AbsorptionAmount:5": 0.0,
+            "Air:2": 300,
+            "ArmorDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085,
+              "2:5": 0.085,
+              "3:5": 0.085
+            },
+            "ArmorItems:9": {
+              "0:10": {},
+              "1:10": {},
+              "2:10": {},
+              "3:10": {}
+            },
+            "Attributes:9": {
+              "0:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.slash"
+              },
+              "1:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.pierce"
+              },
+              "2:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.impact"
+              },
+              "3:10": {
+                "Base:6": 3000.0,
+                "Name:8": "generic.maxHealth"
+              },
+              "4:10": {
+                "Base:6": 1.0,
+                "Name:8": "generic.knockbackResistance"
+              },
+              "5:10": {
+                "Base:6": 0.329,
+                "Name:8": "generic.movementSpeed"
+              },
+              "6:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armor"
+              },
+              "7:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armorToughness"
+              },
+              "8:10": {
+                "Base:6": 1.0,
+                "Name:8": "forge.swimSpeed"
+              },
+              "9:10": {
+                "Base:6": 16.0,
+                "Name:8": "generic.followRange"
+              },
+              "10:10": {
+                "Base:6": 25.0,
+                "Name:8": "generic.attackDamage"
+              }
+            },
+            "CanPickUpLoot:1": 0,
+            "DeathTime:2": 0,
+            "Dimension:3": 0,
+            "FallDistance:5": 0.0,
+            "FallFlying:1": 0,
+            "Fire:2": -1,
+            "ForgeCaps:10": {
+              "aether:entityinfo:10": {
+                "hasSpawnArea:1": 0
+              },
+              "aether:statuseffects:10": {},
+              "cavern:portal_cache:10": {
+                "LastDim:9": {},
+                "LastPos:9": {}
+              },
+              "dsurround:data:10": {
+                "a:1": 0,
+                "f:1": 0
+              },
+              "dsurround:entityfx:10": {},
+              "dsurround:speech:10": {},
+              "enderutilities:entity_portal_cooldown:10": {
+                "LastInPortal:4": 0
+              },
+              "thebetweenlands:custom_step_sound:10": {},
+              "thebetweenlands:entity_gems:10": {
+                "gems:9": {}
+              },
+              "thebetweenlands:equipment:10": {
+                "amuletSlots:3": 1
+              },
+              "thebetweenlands:puppet:10": {
+                "guard:1": 0,
+                "recruitmentCost:3": 0,
+                "stay:1": 0,
+                "ticks:3": 0
+              },
+              "tinkertoolleveling:entityxp:9": {},
+              "twilightforest:cap_shield:10": {
+                "permshields:3": 0,
+                "tempshields:3": 0
+              }
+            },
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
+            "HandDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085
+            },
+            "HandItems:9": {
+              "0:10": {},
+              "1:10": {}
+            },
+            "Health:5": 3000.0,
+            "HurtByTimestamp:3": 0,
+            "HurtTime:2": 0,
+            "Invulnerable:1": 0,
+            "Leashed:1": 0,
+            "LeftHanded:1": 0,
+            "Motion:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "OnGround:1": 0,
+            "PersistenceRequired:1": 0,
+            "PortalCooldown:3": 0,
+            "Pos:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "RelativeAABB:9": {
+              "0:6": -0.30000001192092896,
+              "1:6": 0.0,
+              "2:6": -0.30000001192092896,
+              "3:6": 0.699999988079071,
+              "4:6": 3.125,
+              "5:6": 0.699999988079071
+            },
+            "Rotation:9": {
+              "0:5": 2.8397744,
+              "1:5": 0.0
+            },
+            "SurgeAABB:9": {
+              "0:6": -0.30000001192092896,
+              "1:6": 0.0,
+              "2:6": -0.30000001192092896,
+              "3:6": 0.699999988079071,
+              "4:6": 3.125,
+              "5:6": 0.699999988079071
+            },
+            "UUIDLeast:4": -7278092987340621142,
+            "UUIDMost:4": -4521979021923038321,
+            "UpdateBlocked:1": 0,
+            "id:8": "aoa3:xxeus"
+          },
+          "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 2,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:xxeus_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
+        }
+      }
+    },
+    "1561:10": {
+      "preRequisites:11": [
+        567514731,
+        1086
+      ],
+      "properties:10": {
+        "betterquesting:10": {
+          "desc:8": "     The second of the §8§oPrimordial Five§r. Shoots projectiles that debuff you and heal it.",
+          "icon:10": {
+            "Count:3": 1,
+            "id:8": "aoa3:ornate_miskel_statue"
+          },
+          "name:8": "Miskel",
+          "questlogic:8": "OR",
+          "snd_complete:8": "contenttweaker:questcommon",
+          "snd_update:8": "contenttweaker:questcommon",
+          "tasklogic:8": "OR"
+        }
+      },
+      "questID:3": 1796449058,
+      "rewards:9": {
+        "0:10": {
+          "amount:3": 85,
+          "index:3": 0,
+          "rewardID:8": "bq_standard:xp"
+        }
+      },
+      "tasks:9": {
+        "0:10": {
+          "index:3": 0,
+          "target:8": "aoa3:miskel",
+          "targetNBT:10": {
+            "AABB:9": {
+              "0:6": -0.3499999940395355,
+              "1:6": 0.0,
+              "2:6": -0.3499999940395355,
+              "3:6": 0.3499999940395355,
+              "4:6": 2.375,
+              "5:6": 0.3499999940395355
+            },
+            "AbsorptionAmount:5": 0.0,
+            "Air:2": 300,
+            "ArmorDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085,
+              "2:5": 0.085,
+              "3:5": 0.085
+            },
+            "ArmorItems:9": {
+              "0:10": {},
+              "1:10": {},
+              "2:10": {},
+              "3:10": {}
+            },
+            "Attributes:9": {
+              "0:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.projectileDamage"
+              },
+              "1:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.magicDamage"
+              },
+              "2:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.jumpHeight"
+              },
+              "3:10": {
+                "Base:6": 1.0,
+                "Name:8": "potioncore.damageResistance"
+              },
+              "4:10": {
+                "Base:6": 0.0,
+                "Name:8": "potioncore.magicShielding"
+              },
+              "5:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.slash"
+              },
+              "6:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.pierce"
+              },
+              "7:10": {
+                "Base:6": 0.0,
+                "Name:8": "attribute.name.aether.impact"
+              },
+              "8:10": {
+                "Base:6": 1300.0,
+                "Name:8": "generic.maxHealth"
+              },
+              "9:10": {
+                "Base:6": 0.4,
+                "Name:8": "generic.knockbackResistance"
+              },
+              "10:10": {
+                "Base:6": 0.207,
+                "Name:8": "generic.movementSpeed"
+              },
+              "11:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armor"
+              },
+              "12:10": {
+                "Base:6": 0.0,
+                "Name:8": "generic.armorToughness"
+              },
+              "13:10": {
+                "Base:6": 1.0,
+                "Name:8": "forge.swimSpeed"
+              },
+              "14:10": {
+                "Base:6": 24.0,
+                "Name:8": "generic.followRange"
+              },
+              "15:10": {
+                "Base:6": 2.0,
+                "Name:8": "generic.attackDamage"
+              }
+            },
+            "CanPickUpLoot:1": 0,
+            "DeathTime:2": 0,
+            "Dimension:3": 428,
+            "FallDistance:5": 0.0,
+            "FallFlying:1": 0,
+            "Fire:2": -1,
+            "ForgeCaps:10": {
+              "aether:entityinfo:10": {
+                "hasSpawnArea:1": 0
+              },
+              "aether:statuseffects:10": {
+                "statusEffects:9": {}
+              },
+              "cavern:portal_cache:10": {
+                "LastDim:9": {},
+                "LastPos:9": {}
+              },
+              "dsurround:data:10": {
+                "a:1": 0,
+                "f:1": 0
+              },
+              "dsurround:entityfx:10": {},
+              "dsurround:speech:10": {},
+              "thebetweenlands:custom_step_sound:10": {},
+              "thebetweenlands:entity_gems:10": {
+                "gems:9": {}
+              },
+              "thebetweenlands:equipment:10": {
+                "amuletSlots:3": 1
+              },
+              "thebetweenlands:puppet:10": {
+                "guard:1": 0,
+                "recruitmentCost:3": 0,
+                "stay:1": 0,
+                "ticks:3": 0
+              },
+              "tinkertoolleveling:entityxp:9": {},
+              "twilightforest:cap_boss:10": {
+                "homePos:10": {
+                  "X:3": 0,
+                  "Y:3": 0,
+                  "Z:3": 0
+                },
+                "variant:3": -1
+              },
+              "twilightforest:cap_shield:10": {
+                "permshields:3": 0,
+                "tempshields:3": 0
+              }
+            },
+            "ForgeData:10": {
+              "isFakeEntityForMoBends:1": 1
+            },
+            "HandDropChances:9": {
+              "0:5": 0.085,
+              "1:5": 0.085
+            },
+            "HandItems:9": {
+              "0:10": {},
+              "1:10": {}
+            },
+            "Health:5": 1300.0,
+            "HurtByTimestamp:3": 0,
+            "HurtTime:2": 0,
+            "Invulnerable:1": 0,
+            "Leashed:1": 0,
+            "LeftHanded:1": 0,
+            "Motion:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "OnGround:1": 0,
+            "PersistenceRequired:1": 0,
+            "PortalCooldown:3": 0,
+            "Pos:9": {
+              "0:6": 0.0,
+              "1:6": 0.0,
+              "2:6": 0.0
+            },
+            "Rotation:9": {
+              "0:5": 2.1033132,
+              "1:5": 0.0
+            },
+            "UUIDLeast:4": -7185153099786218750,
+            "UUIDMost:4": 6037543669314768661,
+            "UpdateBlocked:1": 0,
+            "gravityFactor:6": 1.0,
+            "id:8": "aoa3:miskel"
+          },
+          "taskID:8": "bq_standard:hunt"
+        },
+        "1:10": {
+          "index:3": 1,
+          "requiredItems:9": {
+            "0:10": {
+              "Count:3": 1,
+              "id:8": "aoa3:miskel_statue"
+            }
+          },
+          "taskID:8": "bq_standard:retrieval"
+        }
+      }
+    },
+    "1562:10": {
+      "properties:10": {
+        "betterquesting:10": {
+          "desc:8": "No Description",
+          "icon:10": {
+            "Count:3": 1,
+            "id:8": "minecraft:nether_star"
+          },
+          "name:8": "New Quest"
+        }
+      },
+      "questID:3": 1902364702,
+      "tasks:9": {}
     }
   },
   "questLines:9": {
@@ -74305,7 +78923,7 @@
           "id:3": 34,
           "sizeX:3": 24,
           "sizeY:3": 24,
-          "x:3": 204,
+          "x:3": 168,
           "y:3": -240
         },
         "5:10": {
@@ -74617,179 +79235,179 @@
           "y:3": -240
         },
         "49:10": {
-          "id:3": 1033,
+          "id:3": 1049,
           "sizeX:3": 24,
           "sizeY:3": 24,
           "x:3": 96,
           "y:3": -240
         },
         "50:10": {
-          "id:3": 1049,
+          "id:3": 1056,
           "sizeX:3": 24,
           "sizeY:3": 24,
           "x:3": 132,
           "y:3": -240
         },
         "51:10": {
-          "id:3": 1056,
-          "sizeX:3": 24,
-          "sizeY:3": 24,
-          "x:3": 168,
-          "y:3": -240
-        },
-        "52:10": {
           "id:3": 1057,
           "sizeX:3": 24,
           "sizeY:3": 24,
           "x:3": 348,
           "y:3": -204
         },
-        "53:10": {
+        "52:10": {
           "id:3": 1062,
           "sizeX:3": 24,
           "sizeY:3": 24,
           "x:3": -192,
           "y:3": -276
         },
-        "54:10": {
+        "53:10": {
           "id:3": 1063,
           "sizeX:3": 24,
           "sizeY:3": 24,
           "x:3": -156,
           "y:3": -276
         },
-        "55:10": {
+        "54:10": {
           "id:3": 1064,
           "sizeX:3": 24,
           "sizeY:3": 24,
           "x:3": -120,
           "y:3": -276
         },
-        "56:10": {
+        "55:10": {
           "id:3": 1065,
           "sizeX:3": 24,
           "sizeY:3": 24,
           "x:3": -84,
           "y:3": -276
         },
-        "57:10": {
+        "56:10": {
           "id:3": 1080,
           "sizeX:3": 24,
           "sizeY:3": 24,
           "x:3": -48,
           "y:3": -276
         },
-        "58:10": {
+        "57:10": {
           "id:3": 1081,
           "sizeX:3": 24,
           "sizeY:3": 24,
           "x:3": -12,
           "y:3": -276
         },
-        "59:10": {
+        "58:10": {
           "id:3": 1082,
           "sizeX:3": 24,
           "sizeY:3": 24,
           "x:3": 24,
           "y:3": -276
         },
-        "60:10": {
+        "59:10": {
           "id:3": 1083,
           "sizeX:3": 24,
           "sizeY:3": 24,
           "x:3": 60,
           "y:3": -276
         },
-        "61:10": {
+        "60:10": {
           "id:3": 1087,
           "sizeX:3": 24,
           "sizeY:3": 24,
           "x:3": 96,
           "y:3": -276
         },
-        "62:10": {
-          "id:3": 1088,
+        "61:10": {
+          "id:3": 1097,
           "sizeX:3": 24,
           "sizeY:3": 24,
           "x:3": 132,
           "y:3": -276
         },
+        "62:10": {
+          "id:3": 1098,
+          "sizeX:3": 24,
+          "sizeY:3": 24,
+          "x:3": 132,
+          "y:3": -204
+        },
         "63:10": {
-          "id:3": 1097,
+          "id:3": 1106,
+          "sizeX:3": 24,
+          "sizeY:3": 24,
+          "x:3": 168,
+          "y:3": -204
+        },
+        "64:10": {
+          "id:3": 1107,
           "sizeX:3": 24,
           "sizeY:3": 24,
           "x:3": 168,
           "y:3": -276
         },
-        "64:10": {
-          "id:3": 1098,
-          "sizeX:3": 24,
-          "sizeY:3": 24,
-          "x:3": 204,
-          "y:3": -276
-        },
         "65:10": {
-          "id:3": 1106,
-          "sizeX:3": 24,
-          "sizeY:3": 24,
-          "x:3": 240,
-          "y:3": -276
-        },
-        "66:10": {
-          "id:3": 1107,
-          "sizeX:3": 24,
-          "sizeY:3": 24,
-          "x:3": 276,
-          "y:3": -276
-        },
-        "67:10": {
           "id:3": 1115,
           "sizeX:3": 24,
           "sizeY:3": 24,
           "x:3": -192,
           "y:3": -312
         },
-        "68:10": {
+        "66:10": {
           "id:3": 1470,
           "sizeX:3": 24,
           "sizeY:3": 24,
           "x:3": 276,
           "y:3": -96
         },
-        "69:10": {
+        "67:10": {
           "id:3": 1508,
           "sizeX:3": 24,
           "sizeY:3": 24,
           "x:3": 312,
           "y:3": -96
         },
-        "70:10": {
+        "68:10": {
           "id:3": 1509,
           "sizeX:3": 24,
           "sizeY:3": 24,
           "x:3": 348,
           "y:3": -96
         },
-        "71:10": {
+        "69:10": {
           "id:3": 1510,
           "sizeX:3": 24,
           "sizeY:3": 24,
           "x:3": 384,
           "y:3": -96
         },
-        "72:10": {
+        "70:10": {
           "id:3": 1528,
           "sizeX:3": 24,
           "sizeY:3": 24,
           "x:3": 348,
           "y:3": -132
         },
-        "73:10": {
+        "71:10": {
           "id:3": 1529,
           "sizeX:3": 24,
           "sizeY:3": 24,
           "x:3": -12,
           "y:3": -96
+        },
+        "72:10": {
+          "id:3": 81686143,
+          "sizeX:3": 24,
+          "sizeY:3": 24,
+          "x:3": 168,
+          "y:3": -312
+        },
+        "73:10": {
+          "id:3": 287457859,
+          "sizeX:3": 24,
+          "sizeY:3": 24,
+          "x:3": 96,
+          "y:3": -312
         },
         "74:10": {
           "id:3": 297079895,
@@ -74799,11 +79417,67 @@
           "y:3": 12
         },
         "75:10": {
+          "id:3": 475586045,
+          "sizeX:3": 24,
+          "sizeY:3": 24,
+          "x:3": -48,
+          "y:3": -312
+        },
+        "76:10": {
+          "id:3": 482665851,
+          "sizeX:3": 24,
+          "sizeY:3": 24,
+          "x:3": -12,
+          "y:3": -312
+        },
+        "77:10": {
+          "id:3": 567514731,
+          "sizeX:3": 24,
+          "sizeY:3": 24,
+          "x:3": -120,
+          "y:3": -312
+        },
+        "78:10": {
+          "id:3": 783863246,
+          "sizeX:3": 24,
+          "sizeY:3": 24,
+          "x:3": 132,
+          "y:3": -312
+        },
+        "79:10": {
+          "id:3": 1161281890,
+          "sizeX:3": 24,
+          "sizeY:3": 24,
+          "x:3": 60,
+          "y:3": -312
+        },
+        "80:10": {
+          "id:3": 1260129780,
+          "sizeX:3": 24,
+          "sizeY:3": 24,
+          "x:3": 24,
+          "y:3": -312
+        },
+        "81:10": {
           "id:3": 1428433352,
           "sizeX:3": 24,
           "sizeY:3": 24,
           "x:3": -12,
           "y:3": 12
+        },
+        "82:10": {
+          "id:3": 1764361271,
+          "sizeX:3": 24,
+          "sizeY:3": 24,
+          "x:3": -156,
+          "y:3": -312
+        },
+        "83:10": {
+          "id:3": 1796449058,
+          "sizeX:3": 24,
+          "sizeY:3": 24,
+          "x:3": -84,
+          "y:3": -312
         }
       }
     },
@@ -79171,8 +83845,8 @@
           "id:3": 1030965859,
           "sizeX:3": 24,
           "sizeY:3": 24,
-          "x:3": -156,
-          "y:3": -84
+          "x:3": -144,
+          "y:3": -108
         },
         "53:10": {
           "id:3": 1223527586,
@@ -79192,8 +83866,8 @@
           "id:3": 1506915266,
           "sizeX:3": 24,
           "sizeY:3": 24,
-          "x:3": -156,
-          "y:3": -108
+          "x:3": -144,
+          "y:3": -84
         }
       }
     },


### PR DESCRIPTION
This
- Splits the boss quests of "bosses" consisting of multiple boss entities so it's one per entity (the guardian statue is red only sadly, there are arguments to change that icon to the spawnegg as well but I wanted to make it obvious on quick glance that it's guardians) and slightly moves the aoa quests (the old quests were removed, not deleted, _also I did not touch the "All of the quests" quest at all so far_). This is because kill tasks can only have one mob, and you cannot do "(kill AND kill) OR collect"

![grafik](https://github.com/user-attachments/assets/dca33756-3e41-41bf-a19b-ff4a7ee9f675)

- Changes the relevant quest requirements

- Adds one (or more (lich, and _especially_ pharaoh because the only set of items unique to the pharaoh is the long list of artifacts)), usually guaranteed (crushroom has no guaranteed drops), drop to the quests so they are completable via kill OR via collecting the item. if it's multiple items, you only need to collect one.

![grafik](https://github.com/user-attachments/assets/900d0f12-8ca5-463a-aae5-cee0dd1f21a7)

- Should make sure that there are no or at least less issues with the boss quests in multiplayer (due to kill tasks not syncing)

- Increases the xp rewards, especially towards later chapters, and makes them more consistent (especially aoa)