### PR TITLE
Update quest_issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/quest_issue.md
+++ b/.github/ISSUE_TEMPLATE/quest_issue.md
@@ -14,7 +14,7 @@ assignees: 'TheComputerizer'
 [The name of the questline or questlines the issue falls under. If there are multiple list them all out (even duplicated) in the same order]
 
 **Quest**
-[The name ***and*** number of the quest. The number of the quest can be seen next to the name when advanced tooltip (F3 + H) is turned on. If there are multiple list them out in the same order as you did for the questlines]
+[The name ***and*** number of the quest. The number of the quest can be obtained by right-clicking the quest and clicking "Copy Quest ID". If there are multiple list them out in the same order as you did for the questlines]
 
 **Describe the issue**
 [A clear and concise description of what the issue is. Give as much detail as possible preferrably without a wall of text]


### PR DESCRIPTION
quest IDs are now obtained in a different way (due to them being random and long they are no longer displayed but can just be copied instead)