### PR TITLE
decrease mob grinder energy usage

### DIFF
--- a/config/brandon3055/DraconicEvolution.cfg
+++ b/config/brandon3055/DraconicEvolution.cfg
@@ -242,7 +242,7 @@ Tweaks {
      >
 
     # Sets the energy per use per heart of damage for the grinder.
-    I:grinderEnergyPerHeart=80
+    I:grinderEnergyPerHeart=1
 
     # Set to false if you dont want the guardian to be able to kill creative players.
     # Alternatively... Just dont poke the guardian if you dont want to die!


### PR DESCRIPTION
The Draconic Evolution Mob Grinder is a direct upgrade to the Mob Slaughter Factory, but has issues, especially on higher difficulties:
- The Mob Grinder can only damage one mob at a time
- It takes 80 RF per heart
- It has a max RF storage of 500kRF => ~6k damage per tick which is not enough for masochist/lategame mobfarms
- You cannot change the max RF storage via the config

My first idea was to massively increase the max RF storage to 500MRF, but since that is not possible (it should be with mixins), this massively decreases the RF/heart instead (80 -> 1), increasing the max amount of mobs killed per tick by still less than my first idea.