### PR TITLE
Make Binnie's Botany Pollen obtainable

### DIFF
--- a/scripts/crafttweaker/late/misc/JEIDescriptions.zs
+++ b/scripts/crafttweaker/late/misc/JEIDescriptions.zs
@@ -26,9 +26,9 @@ JEI.addDescription(<botany:pigment:*>,
     "Some colors may only be obtained by cross-breeding hybrid flowers"]);
 
 JEI.addDescription(<botany:pollen>,
-	["Can be obtained by crafting a Germling with a Pollen Collection Kit."
-	"The NBT data of the Germling gets transferred to the Pollen."
-	"JEI will always show Corrupted Flowers. This is due to some calculations"
+	["Can be obtained by crafting a Germling with a Pollen Collection Kit.",
+	"The NBT data of the Germling gets transferred to the Pollen.",
+	"JEI will always show Corrupted Flowers. This is due to some calculations",
 	"that need to happen during crafting."]);
 
 //dimhoppertweaks-----------------------------------------------------------------------------------------------------------

--- a/scripts/crafttweaker/late/misc/JEIDescriptions.zs
+++ b/scripts/crafttweaker/late/misc/JEIDescriptions.zs
@@ -25,6 +25,12 @@ JEI.addDescription(<botany:pigment:*>,
     "Due to how the color data processing for the flowers are handled these will not show up as recipes.",
     "Some colors may only be obtained by cross-breeding hybrid flowers"]);
 
+JEI.addDescription(<botany:pollen>,
+	["Can be obtained by crafting a Germling with a Pollen Collection Kit."
+	"The NBT data of the Germling gets transferred to the Pollen."
+	"JEI will always show Corrupted Flowers. This is due to some calculations"
+	"that need to happen during crafting."]);
+
 //dimhoppertweaks-----------------------------------------------------------------------------------------------------------
 JEI.addDescription(<dimhoppertweaks:recipe_function>, 
     "This is an indicator that the output item may not be displayed correctly due to some calculations that need to happen during crafting.",

--- a/scripts/crafttweaker/late/misc/JEIDescriptions.zs
+++ b/scripts/crafttweaker/late/misc/JEIDescriptions.zs
@@ -26,10 +26,8 @@ JEI.addDescription(<botany:pigment:*>,
     "Some colors may only be obtained by cross-breeding hybrid flowers"]);
 
 JEI.addDescription(<botany:pollen>,
-	["Can be obtained by crafting a Germling with a Pollen Collection Kit.",
-	"The NBT data of the Germling gets transferred to the Pollen.",
-	"JEI will always show Corrupted Flowers. This is due to some calculations",
-	"that need to happen during crafting."]);
+    ["Can be obtained by crafting a Germling with a Pollen Collection Kit. The NBT data of the Germling gets transferred to the Pollen.",
+    "JEI will always show Corrupted Flowers. This is due to some calculations that need to happen during crafting."]);
 
 //dimhoppertweaks-----------------------------------------------------------------------------------------------------------
 JEI.addDescription(<dimhoppertweaks:recipe_function>, 

--- a/scripts/crafttweaker/mid/additions/vanilla/Crafting.zs
+++ b/scripts/crafttweaker/mid/additions/vanilla/Crafting.zs
@@ -553,6 +553,12 @@ static shapelessBuilders as Holder[] = [
 
     Util.shapeless(<botania:grassseeds:3>, [<botania:grassseeds>, <ore:bushPlant>]), //Dry Pasture Seeds
 
+    //botany------------------------------------------------------------------------------------------------------
+    Util.shapeless(<botany:pollen>, [<botany:seed>.marked("seed"), <gendustry:pollen_kit>]).addFunction(
+	function(out, ins, info) {
+	    return out.withTag(ins.seed.tag);
+        } as IRecipeFunction), //Binnie's Pollen	
+
     //contenttweaker--------------------------------------------------------------------------------------------------------
     Util.shapeless(<contenttweaker:bloq>, [<extrautils2:machine>.withTag({Type: "extrautils2:enchanter"})]), //Bloq
 

--- a/scripts/crafttweaker/mid/additions/vanilla/Crafting.zs
+++ b/scripts/crafttweaker/mid/additions/vanilla/Crafting.zs
@@ -557,7 +557,7 @@ static shapelessBuilders as Holder[] = [
     Util.shapeless(<botany:pollen>, [<botany:seed>.marked("seed"), <gendustry:pollen_kit>]).addFunction(
 	function(out, ins, info) {
 	    return out.withTag(ins.seed.tag);
-        } as IRecipeFunction), //Binnie's Pollen	
+        } as IRecipeFunction), //Pollen	
 
     //contenttweaker--------------------------------------------------------------------------------------------------------
     Util.shapeless(<contenttweaker:bloq>, [<extrautils2:machine>.withTag({Type: "extrautils2:enchanter"})]), //Bloq


### PR DESCRIPTION
Them not being obtainable is the only thing stopping people from using Binnie's Genetics with it.

JEI shows Corrupted Flowers, that's why the description got added
![grafik](https://github.com/user-attachments/assets/f68d5e05-d7b0-4aad-9205-d8c3e2ee8631)
![grafik](https://github.com/user-attachments/assets/3982a4b8-6771-4678-b2e1-92e64298ffa1)

however it does correctly copy the NBT when actually crafting
![grafik](https://github.com/user-attachments/assets/1446c984-0d4d-4cd0-b31d-20bbfa1ecadc)
![grafik](https://github.com/user-attachments/assets/86eb57b1-2354-422c-8135-9bd5047c5d4f)
