### PR TITLE
Change dimensional singularity quest reward from `@p` to `@s`

### DIFF
--- a/config/betterquesting/DefaultQuests.json
+++ b/config/betterquesting/DefaultQuests.json
@@ -34959,6 +34959,7 @@
       "questID:3": 792,
       "tasks:9": {
         "0:10": {
+		  "ignoreNBT:1": 1,
           "index:3": 0,
           "requiredItems:9": {
             "0:10": {


### PR DESCRIPTION
This changes the command reward from the quest with the id 1257.

Was: `gamestage silentadd @p bedrockfinal`
Now is: `gamestage silentadd @s bedrockfinal`

This makes it consistent with all other gamestage questrewards and prevents it from potentially not working.

Edit: I might have forgotten that `@` pings people, sorry to the two people that randomly got pinged