### PR TITLE
Recipe for Red String

### DIFF
--- a/scripts/crafttweaker/mid/additions/artisans/Mage.zs
+++ b/scripts/crafttweaker/mid/additions/artisans/Mage.zs
@@ -239,6 +239,10 @@ static shapedHolders as Holder[] = [
 ] as Holder[];
 
 static shapelessHolders as Holder[] = [
+  //botania
+  Util.shapeless(<botania:manaresource:12>, [<botania:manaresource:16>, <botania:manaresource:15>, <botania:manaresource:8>, <calculator:material:9>, <botania:felpumpkin>])
+  .addTools({<ore:artisansNeedle>:25}), //Red String
+
   //enderio
   Util.shapeless(<enderio:block_powered_spawner>, [<enderio:block_powered_spawner>, <enderio:item_broken_spawner>]).setMarkIndex(1)
     .addFunction(function(output, map, info) {


### PR DESCRIPTION
This fixes #31 

This adds the following recipe for red string:
![grafik](https://github.com/user-attachments/assets/025b70cb-7d04-4ad1-bccb-f355ad3adb86)

Default recipe for comparison:
![grafik](https://github.com/user-attachments/assets/5f9ae95e-5c05-4dc9-83d9-7a39535f7821)
