### PR TITLE
Naquadah Alloy Automation

### DIFF
--- a/scripts/crafttweaker/addingrecipes/bymod/immersiveengineering/crusher.zs
+++ b/scripts/crafttweaker/addingrecipes/bymod/immersiveengineering/crusher.zs
@@ -20,3 +20,6 @@ Crusher.removeRecipesForInput(<immersiveengineering:material:6>);
 Crusher.removeRecipesForInput(<immersiveengineering:stone_decoration:3>);
 Crusher.addRecipe(<immersiveengineering:material:17>, <thermalfoundation:material:802>, 5000);
 Crusher.addRecipe(<immersiveengineering:material:17>*9, <thermalfoundation:storage_resource:1>, 50000);
+
+//Naquadah
+Crusher.addRecipe(<sgcraft:naquadah>*2, <sgcraft:naquadahore>, 5000, <jaopca:dust.naquadah_alloy>, 0.1);

--- a/scripts/crafttweaker/addingrecipes/bymod/integrateddynamics/mechanicalsqueezer.zs
+++ b/scripts/crafttweaker/addingrecipes/bymod/integrateddynamics/mechanicalsqueezer.zs
@@ -7,3 +7,8 @@ import mods.integrateddynamics.MechanicalSqueezer;
 MechanicalSqueezer.addRecipe(<silentgems:essenceore>,
 	<silentgems:craftingmaterial:3>*4,1,
 	<silentgems:craftingmaterial:3>*2,0.5);
+//Naquadah
+MechanicalSqueezer.addRecipe(<sgcraft:naquadahore>,
+	<sgcraft:naquadah>,2,
+	<sgcraft:naquadah>,0.5,
+	<jaopca:dust.naquadah_alloy>,0.1);

--- a/scripts/crafttweaker/addingrecipes/bymod/integrateddynamics/mechanicalsqueezer.zs
+++ b/scripts/crafttweaker/addingrecipes/bymod/integrateddynamics/mechanicalsqueezer.zs
@@ -9,6 +9,6 @@ MechanicalSqueezer.addRecipe(<silentgems:essenceore>,
 	<silentgems:craftingmaterial:3>*2,0.5);
 //Naquadah
 MechanicalSqueezer.addRecipe(<sgcraft:naquadahore>,
-	<sgcraft:naquadah>,2,
+	<sgcraft:naquadah>*2,2,
 	<sgcraft:naquadah>,0.5,
 	<jaopca:dust.naquadah_alloy>,0.1);

--- a/scripts/crafttweaker/addingrecipes/bymod/integrateddynamics/squeezer.zs
+++ b/scripts/crafttweaker/addingrecipes/bymod/integrateddynamics/squeezer.zs
@@ -7,3 +7,8 @@ import mods.integrateddynamics.Squeezer;
 Squeezer.addRecipe(<silentgems:essenceore>,
 	<silentgems:craftingmaterial:3>*3,1,
 	<silentgems:craftingmaterial:3>,0.75);
+//Naquadah
+Squeezer.addRecipe(<sgcraft:naquadahore>,
+	<sgcraft:naquadah>,1,
+	<sgcraft:naquadah>,0.75,
+	<jaopca:dust.naquadah_alloy>,0.05);

--- a/scripts/crafttweaker/mid/additions/enderio/SagMill.zs
+++ b/scripts/crafttweaker/mid/additions/enderio/SagMill.zs
@@ -9,6 +9,8 @@ static recipes as Recipe[] = [
     Recipe(<thermalfoundation:ore:2>, [<thermalfoundation:material:66>*2, <minecraft:cobblestone>]),    //silver ore
     Recipe(<thermalfoundation:ore:5>, [<thermalfoundation:material:69>*2, <minecraft:cobblestone>]),    //nickel ore
     Recipe(<thermalfoundation:ore:6>, [<thermalfoundation:material:70>*2, <minecraft:cobblestone>]),    //iridium ore
+    Recipe(<sgcraft:naquadahore>, [<sgcraft:naquadah>*2, <minecraft:cobblestone>, <jaopca:dust.naquadah_alloy>])
+		.setChances([1.0, 0.15, 0.1] as float[]).setEnergy(50000).setXP([500, 100, 50] as float[]),		//Naquadah Ore
 ];
 
 function run() {

--- a/scripts/crafttweaker/mid/additions/mekanism/Combiner.zs
+++ b/scripts/crafttweaker/mid/additions/mekanism/Combiner.zs
@@ -5,3 +5,6 @@ combiner.addRecipe(<extendedcrafting:material:40>, <appliedenergistics2:material
 
 //potassium iodide
 combiner.addRecipe(<extraplanets:potassium>*3, <forestry:iodine_capsule>*3, <extraplanets:potassium_iodide>);
+
+//Naquadah Ore
+combiner.addRecipe(<sgcraft:naquadah>*8, <minecraft:cobblestone>, <sgcraft:naquadahore>);

--- a/scripts/crafttweaker/mid/additions/mekanism/EnrichmentChamber.zs
+++ b/scripts/crafttweaker/mid/additions/mekanism/EnrichmentChamber.zs
@@ -1,0 +1,3 @@
+import mods.mekanism.enrichment;
+
+enrichment.addRecipe(<sgcraft:naquadahore>, <sgcraft:naquadah>*2);

--- a/scripts/crafttweaker/mid/additions/thermal/Pulverizer.zs
+++ b/scripts/crafttweaker/mid/additions/thermal/Pulverizer.zs
@@ -13,3 +13,6 @@ Pulverizer.addRecipe(<bigreactors:dustgraphite>, <aoa3:ancient_rock>, 100000);
 
 //flint
 Pulverizer.addRecipe(<jaopca:dust.flint>, <minecraft:flint>*4, 1000);
+
+//Naquadah
+Pulverizer.addRecipe(<sgcraft:naquadah>*2, <sgcraft:naquadahore>, 5000, <jaopca:dust.naquadah_alloy>, 10);


### PR DESCRIPTION
This adds a way to automate Naquadah Alloy using Naquadah so that people do not have to rely on chest luck to get it.

Using the combiner, you can now get Naquadah Ore.
![grafik](https://github.com/user-attachments/assets/ce0dcd75-d9cc-4b25-96e9-64a4bac60d70)
I decided against replacing Naquadah with Naquadah Ore in the Void Ore Miners since you only need a handful of Naquadah Alloy Ingots. Also, it may push people towards doing more tech (i.a. Combiner, VOM T1) before progressing to the other planets.
The seemingly high cost of 8 Naquadah per Ore is because 5 would allow a Sag Mill loop. The VOM T1 with a green lens has a 5% chance for Naquadah, so that aint an issue especially because you get some of it back.

As for the processing, I basically copied the Diamond Ore processing recipes, adding a 10% chance for alloy dust where applicable (5% for the non-mechanical ID squeezer). An Alloy Dust to Alloy Ingot recipe already exists.
The following 7 recipes got added (Pulverizer and Tectonic Initiator are from the same Pulverizer.zs recipe):
![grafik](https://github.com/user-attachments/assets/d8543df7-5a02-4a91-a732-93bdec852e99)
![grafik](https://github.com/user-attachments/assets/a69fc5f8-bfba-4e38-a965-725ec7284791)
![grafik](https://github.com/user-attachments/assets/85ecaf50-7533-40fb-9225-3b10370f2968)
![grafik](https://github.com/user-attachments/assets/04f065c9-4a0f-426f-a8cd-d759dc7d7785)
(100% for slot 1, 75% for slot 2, 5% for slot 3)
![grafik](https://github.com/user-attachments/assets/3a963c17-e1f3-4d44-b70d-1095de47c76a)
(100% for slot 1, 50% for slot 2, 10% for slot 3)
![grafik](https://github.com/user-attachments/assets/194e1134-ce42-4830-a7e5-b76dcb8a18dd)
![grafik](https://github.com/user-attachments/assets/58690306-aa0b-44ab-a3a5-deec14a50179)
(100% for slot 1, 15% for slot 2, 10% for slot 3)