### PR TITLE
Fix Limbonic Generator

### DIFF
--- a/config/multiblocked/definition/controller/limbonic_generator.json
+++ b/config/multiblocked/definition/controller/limbonic_generator.json
@@ -254,7 +254,7 @@
       [
         "C            HHH            C",
         "@           HHHHH           E",
-        " C         HHHHHHH         C ",
+        "OC         HHHHHHH         C ",
         " F        HHHHHHHHH        F ",
         " C H     HHHHHHHHHHH     H C ",
         "  CI     HHHHHLHHHHH     IC  ",
@@ -729,7 +729,12 @@
       "item_in": {
         "capability": "item",
         "type": "capability",
-        "io": "BOTH"
+        "io": "IN"
+      },
+	  "item_out": {
+        "capability": "item",
+        "type": "capability",
+        "io": "OUT"
       }
     },
     "symbolMap": {
@@ -783,6 +788,9 @@
       "N": [
         "K",
         "fluid_out"
+      ],
+      "O": [
+        "item_out"
       ]
     }
   }


### PR DESCRIPTION
This fixes #181 by adding an output chest. It's placed directly above the controller.