### PR TITLE
Enchanted Metal recipe

### DIFF
--- a/scripts/crafttweaker/mid/additions/artisans/Mage.zs
+++ b/scripts/crafttweaker/mid/additions/artisans/Mage.zs
@@ -230,6 +230,16 @@ static shapedHolders as Holder[] = [
     .addExtras([<mysticalagriculture:crafting:44>,<mysticalagriculture:crafting:44>,<mysticalagriculture:crafting:44>])
     .addNumbers([90,60,30]), //master infusion crystal
 
+  //Extra Utilities 2
+  Util.bigShaped(<extrautils2:simpledecorative>, "crystal", [
+    <plustic:mirionblock>,
+    <magicbees:resource:13>, 
+    <magicbees:wax>,
+    <thermalfoundation:dye:11>,
+    <botany:pigment:32>,
+    <thermalfoundation:dye:11>])
+    .addTools({<ore:artisansBurner>:300,<ore:artisansLens>:300,<ore:artisansGemCutter>:300}), //Enchanted Metal alt recipe
+
   //overloaded
   Util.bigShaped(<overloaded:nether_star_block>, "thicc", [<xreliquary:witherless_rose>, <minecraft:nether_star>])
     .addTools({<ore:artisansHammer>:420,<ore:artisansAthame>:420,<ore:artisansGrimoire>:420})


### PR DESCRIPTION
This adds the following recipe for Enchanted Metal:

<img width="550" height="432" alt="grafik" src="https://github.com/user-attachments/assets/bb6ff7c7-ce5b-404b-9bf3-80a6237e9c6a" />

It requires the Mage's Workshop, meaning it gets unlocked once you reach the moon (all ingredients can be obtained in chapter 4 post-Betweenlands, but the factory requires the planets gamestage). The intention was to use some items that are annoying to unlock but easy to farm once unlocked (It ia. requires Pigment farming and Bee breeding), while also keeping the cost higher than the ch8 enchanter recipe (the dimensional singularity need ia. a gold block each)

This fixes #79 