### PR TITLE
Industrial Foregoing recipes

### DIFF
--- a/scripts/crafttweaker/mid/additions/vanilla/Crafting.zs
+++ b/scripts/crafttweaker/mid/additions/vanilla/Crafting.zs
@@ -325,6 +325,87 @@ static shapedBuilders as Holder[] = [
                     Damage: map.mark.metadata as short}});
             } as IRecipeFunction), //Hunting Dimension Portal Frame
 
+	//industrialforegoing---------------------------------------------------------------------------------------------------
+	Util.dynamicShaped(<industrialforegoing:conveyor:0>*8, {
+        <industrialforegoing:conveyor>.anyDamage():[0,1,2,3,5,6,7,8],
+		<industrialforegoing:artificial_dye:0>:[4]
+    }), //White Conveyor Belt
+	
+	Util.dynamicShaped(<industrialforegoing:conveyor:1>*8, {
+        <industrialforegoing:conveyor>.anyDamage():[0,1,2,3,5,6,7,8],
+		<industrialforegoing:artificial_dye:1>:[4]
+    }), //Orange Conveyor Belt
+	
+	Util.dynamicShaped(<industrialforegoing:conveyor:2>*8, {
+        <industrialforegoing:conveyor>.anyDamage():[0,1,2,3,5,6,7,8],
+		<industrialforegoing:artificial_dye:2>:[4]
+    }), //Magenta Conveyor Belt
+	
+	Util.dynamicShaped(<industrialforegoing:conveyor:3>*8, {
+        <industrialforegoing:conveyor>.anyDamage():[0,1,2,3,5,6,7,8],
+		<industrialforegoing:artificial_dye:3>:[4]
+    }), //Light Blue Conveyor Belt
+	
+	Util.dynamicShaped(<industrialforegoing:conveyor:4>*8, {
+        <industrialforegoing:conveyor>.anyDamage():[0,1,2,3,5,6,7,8],
+		<industrialforegoing:artificial_dye:4>:[4]
+    }), //Yellow Conveyor Belt
+	
+	Util.dynamicShaped(<industrialforegoing:conveyor:5>*8, {
+        <industrialforegoing:conveyor>.anyDamage():[0,1,2,3,5,6,7,8],
+		<industrialforegoing:artificial_dye:5>:[4]
+    }), //Lime Conveyor Belt
+	
+	Util.dynamicShaped(<industrialforegoing:conveyor:6>*8, {
+        <industrialforegoing:conveyor>.anyDamage():[0,1,2,3,5,6,7,8],
+		<industrialforegoing:artificial_dye:6>:[4]
+    }), //Pink Conveyor Belt
+	
+	Util.dynamicShaped(<industrialforegoing:conveyor:7>*8, {
+        <industrialforegoing:conveyor>.anyDamage():[0,1,2,3,5,6,7,8],
+		<industrialforegoing:artificial_dye:7>:[4]
+    }), //Gray Conveyor Belt
+	
+	Util.dynamicShaped(<industrialforegoing:conveyor:8>*8, {
+        <industrialforegoing:conveyor>.anyDamage():[0,1,2,3,5,6,7,8],
+		<industrialforegoing:artificial_dye:8>:[4]
+    }), //Light Gray Conveyor Belt
+	
+	Util.dynamicShaped(<industrialforegoing:conveyor:9>*8, {
+        <industrialforegoing:conveyor>.anyDamage():[0,1,2,3,5,6,7,8],
+		<industrialforegoing:artificial_dye:9>:[4]
+    }), //Cyan Conveyor Belt
+	
+	Util.dynamicShaped(<industrialforegoing:conveyor:10>*8, {
+        <industrialforegoing:conveyor>.anyDamage():[0,1,2,3,5,6,7,8],
+		<industrialforegoing:artificial_dye:10>:[4]
+    }), //Purple Conveyor Belt
+	
+	Util.dynamicShaped(<industrialforegoing:conveyor:11>*8, {
+        <industrialforegoing:conveyor>.anyDamage():[0,1,2,3,5,6,7,8],
+		<industrialforegoing:artificial_dye:11>:[4]
+    }), //Blue Conveyor Belt
+	
+	Util.dynamicShaped(<industrialforegoing:conveyor:12>*8, {
+        <industrialforegoing:conveyor>.anyDamage():[0,1,2,3,5,6,7,8],
+		<industrialforegoing:artificial_dye:12>:[4]
+    }), //Brown Conveyor Belt
+	
+	Util.dynamicShaped(<industrialforegoing:conveyor:13>*8, {
+        <industrialforegoing:conveyor>.anyDamage():[0,1,2,3,5,6,7,8],
+		<industrialforegoing:artificial_dye:13>:[4]
+    }), //Green Conveyor Belt
+	
+	Util.dynamicShaped(<industrialforegoing:conveyor:14>*8, {
+        <industrialforegoing:conveyor>.anyDamage():[0,1,2,3,5,6,7,8],
+		<industrialforegoing:artificial_dye:14>:[4]
+    }), //Red Conveyor Belt
+	
+	Util.dynamicShaped(<industrialforegoing:conveyor:15>*8, {
+        <industrialforegoing:conveyor>.anyDamage():[0,1,2,3,5,6,7,8],
+		<industrialforegoing:artificial_dye:15>:[4]
+    }), //Black Conveyor Belt
+
     //integrateddynamics----------------------------------------------------------------------------------------------------
 	Util.simpleShaped(<integrateddynamics:part_machine_reader_item>, "part", [
         <enderio:block_simple_furnace>,

--- a/scripts/crafttweaker/mid/additions/vanilla/Crafting.zs
+++ b/scripts/crafttweaker/mid/additions/vanilla/Crafting.zs
@@ -414,6 +414,14 @@ static shapedBuilders as Holder[] = [
         <avaritia:compressed_crafting_table>
     ]), //Machine Reader
 
+	//mekanism-------------------------------------------------------------------------------------------------------------
+	Util.dynamicShaped(<mekanism:teleportationcore>, {
+        <minecraft:diamond>:[0,2,6,8],
+        <mekanism:atomicalloy>:[1,7],
+		<minecraft:gold_ingot>:[3,5],
+        <mekanism:controlcircuit:2>:[4]
+    }), //Teleportation Core
+
     //moreplates------------------------------------------------------------------------------------------------------------
     Util.dynamicShaped(<moreplates:end_steel_gear>, {
         <enderio:item_alloy_nugget:8>:[0,2,6,8],

--- a/scripts/multiblocked/Assembler.zs
+++ b/scripts/multiblocked/Assembler.zs
@@ -38,6 +38,96 @@ static recipes as Recipe[] = [
 
 val assemblerRP as RecipeMap = map;
 
+//Mob Imprisonment Tool
+assemblerRP.start()
+	.duration(600)
+	.perTick(true)
+	.inputFE(1000)
+	.perTick(false)
+	.inputItems(<industrialforegoing:plastic>*4,<minecraft:ghast_tear>,<thermalexpansion:morb:1>)
+	.outputItems(<industrialforegoing:mob_imprisonment_tool>)
+	.buildAndRegister();
+
+//white conveyor belt
+assemblerRP.start()
+	.duration(20)
+	.perTick(true)
+	.inputFE(500)
+	.perTick(false)
+	.inputItems(<enderio:item_material:12>*2,<minecraft:redstone>,<industrialforegoing:plastic>*6,<immersiveengineering:conveyor>*4)
+	.outputItems(<industrialforegoing:conveyor>*4)
+	.buildAndRegister();
+	
+//Extraction Conveyor Upgrade
+assemblerRP.start()
+	.duration(40)
+	.perTick(true)
+	.inputFE(500)
+	.perTick(false)
+	.inputItems(<industrialforegoing:plastic>*8,<moreplates:stellar_alloy_gear>*2,<minecraft:dispenser>,<immersiveengineering:conveyor>.withTag({conveyorType: "immersiveengineering:extract"}))
+	.outputItems(<industrialforegoing:conveyor_upgrade:0>)
+	.buildAndRegister();
+
+//Insertion Conveyor Upgrade
+assemblerRP.start()
+	.duration(40)
+	.perTick(true)
+	.inputFE(500)
+	.perTick(false)
+	.inputItems(<industrialforegoing:plastic>*8,<moreplates:stellar_alloy_gear>*2,<naturesaura:hopper_upgrade>)
+	.outputItems(<industrialforegoing:conveyor_upgrade:1>)
+	.buildAndRegister();
+
+//Detection Conveyor Upgrade
+assemblerRP.start()
+	.duration(40)
+	.perTick(true)
+	.inputFE(500)
+	.perTick(false)
+	.inputItems(<industrialforegoing:plastic>*8,<moreplates:stellar_alloy_gear>*2,<natura:blaze_rail_detector>)
+	.outputItems(<industrialforegoing:conveyor_upgrade:2>)
+	.buildAndRegister();
+
+//Bouncing Conveyor Upgrade
+assemblerRP.start()
+	.duration(40)
+	.perTick(true)
+	.inputFE(500)
+	.perTick(false)
+	.inputItems(<industrialforegoing:plastic>*8,<moreplates:stellar_alloy_gear>*2,<aether:aercloud:1>)
+	.outputItems(<industrialforegoing:conveyor_upgrade:3>)
+	.buildAndRegister();
+
+//Dropping Conveyor Upgrade
+assemblerRP.start()
+	.duration(40)
+	.perTick(true)
+	.inputFE(500)
+	.perTick(false)
+	.inputItems(<industrialforegoing:plastic>*8,<moreplates:stellar_alloy_gear>*2,<minecraft:dropper>,<immersiveengineering:conveyor>.withTag({conveyorType: "immersiveengineering:dropper"}))
+	.outputItems(<industrialforegoing:conveyor_upgrade:4>)
+	.buildAndRegister();
+	
+//Blinking Conveyor Upgrade
+assemblerRP.start()
+	.duration(40)
+	.perTick(true)
+	.inputFE(500)
+	.perTick(false)
+	.inputItems(<industrialforegoing:plastic>*8,<moreplates:stellar_alloy_gear>*2,<mekanism:teleportationcore>)
+	.outputItems(<industrialforegoing:conveyor_upgrade:5>)
+	.buildAndRegister();
+
+//Splitting Conveyor Upgrade
+assemblerRP.start()
+	.duration(40)
+	.perTick(true)
+	.inputFE(500)
+	.perTick(false)
+	.inputItems(<industrialforegoing:plastic>*8,<moreplates:stellar_alloy_gear>*2,<immersiveengineering:conveyor>.withTag({conveyorType: "immersiveengineering:splitter"}))
+	.outputItems(<industrialforegoing:conveyor_upgrade:6>)
+	.buildAndRegister();
+
 //animal grower
 assemblerRP.start()
 	.duration(600)


### PR DESCRIPTION
This adds recipes for certain Industrial Foregoing blocks and items that got their recipes removed by the blanket removal without adding a new recipe. These added recipes are slightly adapted and/or expertified.
- Mob Imprisonment Tool
I thought of it as an upgrade to the reusable Morb. It also can be used to filter mobs for conveyor upgrades.
- Conveyors + conveyor upgrades
They are basically an upgrade to the Immersive Engineering conveyors, including upgrades that other conveyor types do not have like the launching upgrade and the blinking upgrade. Can be very useful for mobfarms since they are way more reliable and configurable than vector plates.
- Teleportation Core
Not IF, but used for the blinking upgrade, and is used in an exchanger recipe, which makes that exchanger obtainable again.