### PR TITLE
Fix record fragment recipe

### DIFF
--- a/scripts/crafttweaker/early/util/Stacks.zs
+++ b/scripts/crafttweaker/early/util/Stacks.zs
@@ -155,7 +155,7 @@ function recordedDisc() as IItemStack {
           if(isNull(tag)) {
             return false;
           }
-          return !isNull(tag.trackID);
+          return !isNull(tag.audio);
         }
         return false;
       });


### PR DESCRIPTION
"The recipe is looking for a 'trackID' tag which was changed to 'audio' in V7 of Music Triggers"