### PR TITLE
Meef Stroganoff ignoreNBT

### DIFF
--- a/config/betterquesting/DefaultQuests.json
+++ b/config/betterquesting/DefaultQuests.json
@@ -9844,6 +9844,7 @@
       "tasks:9": {
         "0:10": {
           "index:3": 0,
+          "ignoreNBT:1": 1,
           "requiredItems:9": {
             "0:10": {
               "Count:3": 1,

--- a/config/betterquesting/DefaultQuests.json
+++ b/config/betterquesting/DefaultQuests.json
@@ -3615,6 +3615,7 @@
         },
         "1:10": {
           "index:3": 2,
+		  "ignoreNBT:1": 1,
           "requiredItems:9": {
             "0:10": {
               "Count:3": 1,


### PR DESCRIPTION
Turned on ignoreNBT for the Meef Stroganoff in the Minoshroom Quest as well as the Rift Blade